### PR TITLE
Issue 42: Add optviz CLI tool, HTML-diff script & GenAI summaries

### DIFF
--- a/generate_diff_html.py
+++ b/generate_diff_html.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import sys
+import subprocess
+import html
+from pathlib import Path
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <IR-file.ll> <opt-flag (e.g. mem2reg or -O2)>")
+        sys.exit(1)
+
+    ir_file, opt_flag = sys.argv[1], sys.argv[2]
+    tool = Path("bin/optviz")
+
+    # 1) Run optviz and capture its diff from stderr
+    proc = subprocess.run(
+        [str(tool), ir_file, f"-opt={opt_flag}"],
+        capture_output=True,
+        text=True
+    )
+    diff_lines = proc.stderr.splitlines()
+
+    # 2) Separate removed (“- ”) and added (“+ ”) instructions
+    removed, added = [], []
+    for line in diff_lines:
+        if line.startswith("- "):
+            removed.append(line[2:])
+        elif line.startswith("+ "):
+            added.append(line[2:])
+
+    # 3) Build HTML table rows
+    rows = []
+    for i in range(max(len(removed), len(added))):
+        rem = html.escape(removed[i]) if i < len(removed) else ""
+        ad  = html.escape(added[i])   if i < len(added)   else ""
+        rows.append(f"<tr><td class='removed'>{rem}</td><td class='added'>{ad}</td></tr>")
+
+    # 4) Emit complete HTML document
+    html_doc = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>IR Diff: {ir_file} [{opt_flag}]</title>
+  <style>
+    body {{ font-family: monospace; padding: 1rem; }}
+    table {{ width: 100%; border-collapse: collapse; }}
+    th, td {{ border: 1px solid #ccc; padding: 4px; vertical-align: top; }}
+    .removed {{ background: #fee; color: #900; }}
+    .added   {{ background: #efe; color: #060; }}
+    th {{ background: #f8f8f8; }}
+  </style>
+</head>
+<body>
+  <h2>IR Diff for <code>{ir_file}</code> (<code>{opt_flag}</code>)</h2>
+  <table>
+    <tr><th>Removed</th><th>Added</th></tr>
+    {''.join(rows)}
+  </table>
+</body>
+</html>
+"""
+
+    out_path = Path("diff.html")
+    out_path.write_text(html_doc)
+    print(f"HTML diff written to {out_path.resolve()}")
+
+if __name__ == "__main__":
+    main()

--- a/llvm/tools/optviz/CmakeLists.txt
+++ b/llvm/tools/optviz/CmakeLists.txt
@@ -1,0 +1,51 @@
+# llvm/tools/optviz/CMakeLists.txt
+
+# Define the tool's sources
+set(OPT_VIZ_SOURCES
+  src/main.cpp
+  src/PassDriver.cpp
+  src/IRDiffer.cpp
+  src/SummaryGen.cpp
+)
+
+# Register as an LLVM tool
+add_llvm_tool(optviz ${OPT_VIZ_SOURCES})
+
+# Link against needed LLVM components
+llvm_map_components_to_libnames(LLVM_OPT_VIZ_LIBS
+  core
+  support
+  irreader
+  option
+)
+target_link_libraries(optviz PRIVATE ${LLVM_OPT_VIZ_LIBS})
+
+# Pull in the standard LLVM compile flags
+llvm_update_compile_flags(optviz)
+
+# ----------------------------------------------------------------------
+# Third-party: libcurl for HTTP + nlohmann/json for JSON parsing
+# ----------------------------------------------------------------------
+
+# libcurl
+find_package(CURL REQUIRED)
+if(CURL_FOUND)
+  message(STATUS "Found CURL: ${CURL_VERSION_STRING}")
+  target_include_directories(optviz PRIVATE ${CURL_INCLUDE_DIRS})
+  target_link_libraries(optviz PRIVATE ${CURL_LIBRARIES})
+else()
+  message(FATAL_ERROR "libcurl is required to build optviz (find_package(CURL) failed)")
+endif()
+
+# nlohmann/json.hpp (single-header)
+find_path(NLOHMANN_JSON_INCLUDE_DIR
+  NAMES nlohmann/json.hpp
+  PATHS /opt/homebrew/include /usr/local/include /usr/include
+)
+if(NLOHMANN_JSON_INCLUDE_DIR)
+  message(STATUS "Found nlohmann/json.hpp at ${NLOHMANN_JSON_INCLUDE_DIR}")
+  # Mark it SYSTEM so its internal warnings are suppressed
+  target_include_directories(optviz SYSTEM PRIVATE ${NLOHMANN_JSON_INCLUDE_DIR})
+else()
+  message(FATAL_ERROR "Could not locate nlohmann/json.hpp. Please brew install nlohmann-json or place it in an include path.")
+endif()

--- a/llvm/tools/optviz/src/IRDiffer.cpp
+++ b/llvm/tools/optviz/src/IRDiffer.cpp
@@ -1,0 +1,172 @@
+// llvm/tools/optviz/src/IRDiffer.cpp
+
+#include "PassDriver.h"
+#include <llvm/IR/Module.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IRReader/IRReader.h>
+#include <llvm/Support/SourceMgr.h>
+#include <llvm/Support/raw_ostream.h>
+#include <llvm/Support/CommandLine.h>
+#include <set>
+#include <string>
+#include <map>
+#include <vector>
+#include <algorithm>
+
+using namespace llvm;
+
+// CLI flags
+static cl::opt<bool> UseColor(
+    "diff-color",
+    cl::desc("Enable ANSI-colored diff output"),
+    cl::init(true)
+);
+
+static cl::opt<std::string> OutputFormat(
+    "format",
+    cl::desc("Output format: plain, side-by-side, or html"),
+    cl::init("plain")
+);
+
+// ANSI color codes
+static const char *RED   = "\x1b[31m";
+static const char *GREEN = "\x1b[32m";
+static const char *RESET = "\x1b[0m";
+
+// Heuristic: skip library or intrinsic calls
+static bool isLibraryCall(const std::string &inst) {
+  if (inst.rfind("call", 0) != 0)
+    return false;
+  return inst.find("@llvm.")  != std::string::npos
+      || inst.find("@__cxa")  != std::string::npos
+      || inst.find("@_ZSt")   != std::string::npos;
+}
+
+// Collect instructions from a function
+static std::set<std::string> collectInsts(Function &F) {
+  std::set<std::string> S;
+  for (auto &BB : F)
+    for (auto &I : BB) {
+      std::string str;
+      raw_string_ostream os(str);
+      I.print(os);
+      S.insert(os.str());
+    }
+  return S;
+}
+
+// Emit HTML header
+static void emitHtmlHeader() {
+  outs() << "<html><head><style>";
+  outs() << ".removed { background-color:#ffe6e6;}";
+  outs() << ".added { background-color:#e6ffe6;}";
+  outs() << "table{border-collapse:collapse;width:100%;}";
+  outs() << "td{vertical-align:top;padding:4px;border:1px solid #ccc;font-family:monospace;}";
+  outs() << "</style></head><body>";
+}
+
+// Emit HTML footer
+static void emitHtmlFooter() {
+  outs() << "</body></html>";
+}
+
+int runIRDiff(const std::string &B, const std::string &A) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+
+  auto M1 = parseIRFile(B, Err, Ctx);
+  auto M2 = parseIRFile(A, Err, Ctx);
+  if (!M1 || !M2) {
+    errs() << "Error parsing IR files.\n";
+    return 1;
+  }
+
+  // Build maps of function->instructions
+  std::map<std::string, std::set<std::string>> BeforeMap, AfterMap;
+  for (auto &F : *M1) if (!F.isDeclaration())
+    BeforeMap[F.getName().str()] = collectInsts(F);
+  for (auto &F : *M2) if (!F.isDeclaration())
+    AfterMap[F.getName().str()] = collectInsts(F);
+
+  // Collect all function names
+  std::set<std::string> FuncNames;
+  for (auto &p : BeforeMap) FuncNames.insert(p.first);
+  for (auto &p : AfterMap)  FuncNames.insert(p.first);
+
+  if (OutputFormat == "html")
+    emitHtmlHeader();
+
+  // Process each function
+  for (auto &fname : FuncNames) {
+    auto &I1 = BeforeMap[fname];
+    auto I2 = AfterMap[fname];
+
+    // Compute diffs
+    std::vector<std::string> Removed, Added;
+    for (auto &s : I1) {
+      if (!isLibraryCall(s) && !I2.count(s)) Removed.push_back(s);
+      else I2.erase(s);
+    }
+    for (auto &s : I2) {
+      if (!isLibraryCall(s)) Added.push_back(s);
+    }
+
+    if (Removed.empty() && Added.empty()) continue;
+
+    if (OutputFormat == "html") {
+      // HTML: table per function
+      outs() << "<h2>Function " << fname << "</h2>";
+      outs() << "<table><tr><th>Removed</th><th>Added</th></tr>";
+      size_t rows = std::max(Removed.size(), Added.size());
+      for (size_t i=0; i<rows; ++i) {
+        outs() << "<tr>";
+        // Removed column
+        outs() << "<td class='removed'>";
+        if (i < Removed.size()) outs() << "- " << Removed[i];
+        outs() << "</td>";
+        // Added column
+        outs() << "<td class='added'>";
+        if (i < Added.size())   outs() << "+ " << Added[i];
+        outs() << "</td></tr>";
+      }
+      outs() << "</table>";
+
+    } else if (OutputFormat == "side-by-side" || OutputFormat == "plain") {
+      // Header
+      errs() << "--- Function " << fname << " ---\n";
+      if (OutputFormat == "side-by-side") {
+        // Side-by-side code as before
+        size_t maxLeft = 0;
+        for (auto &inst : Removed)
+          maxLeft = std::max(maxLeft, inst.size()+2);
+        size_t rows = std::max(Removed.size(), Added.size());
+        for (size_t i=0; i<rows; ++i) {
+          std::string L = (i<Removed.size()? Removed[i]:"");
+          std::string R = (i<Added.size()?   Added[i]  :"");
+          if (!L.empty()) errs() << (UseColor?RED:"-") << "- " << L << (UseColor?RESET:"") ;
+          else            errs() << std::string(maxLeft,' ');
+          size_t pad = maxLeft - ((L.empty()?0:L.size()+2));
+          errs() << std::string(pad,' ') << " | ";
+          if (!R.empty()) errs() << (UseColor?GREEN:"+") << "+ " << R << (UseColor?RESET:"");
+          errs() << "\n";
+        }
+        errs() << "\n";
+      } else {
+        // Plain
+        for (auto &inst : Removed)
+          errs() << (UseColor?RED:"-") << "- " << inst << (UseColor?RESET:"") << "\n";
+        for (auto &inst : Added)
+          errs() << (UseColor?GREEN:"+") << "+ " << inst << (UseColor?RESET:"") << "\n";
+        errs() << "\n";
+      }
+    } else {
+      errs() << "Unknown format: " << OutputFormat << "\n";
+      return 1;
+    }
+  }
+
+  if (OutputFormat == "html")
+    emitHtmlFooter();
+
+  return 0;
+}

--- a/llvm/tools/optviz/src/PassDriver.cpp
+++ b/llvm/tools/optviz/src/PassDriver.cpp
@@ -1,0 +1,100 @@
+// llvm/tools/optviz/src/PassDriver.cpp
+
+#include "PassDriver.h"
+#include "SummaryGen.h"                 // your GenAI summary routines
+#include <llvm/Support/CommandLine.h>
+#include <llvm/Support/raw_ostream.h>
+#include <cstdlib>
+#include <string>
+
+using namespace llvm;
+
+//===----------------------------------------------------------------------===//
+// Command‐line options
+//===----------------------------------------------------------------------===//
+
+static cl::opt<std::string>
+InputFile(cl::Positional,
+          cl::desc("<source.cpp|.ll>"),
+          cl::Required,
+          cl::value_desc("filename"));
+
+static cl::opt<std::string>
+OptMode("opt",
+        cl::desc("Optimization: use -O2 for grouped levels, or pass/pipeline names\n"
+                 "Examples:\n"
+                 "  -opt=-O2\n"
+                 "  -opt=mem2reg\n"
+                 "  -opt=instcombine,loop-unroll"),
+        cl::value_desc("mode"));
+
+static cl::opt<bool>
+GenAISummaries("summary",
+               cl::desc("Auto-generate a natural-language summary of the diff"),
+               cl::init(false));
+
+//===----------------------------------------------------------------------===//
+// runOpt: invoke `opt` to emit IR with the requested transforms
+//===----------------------------------------------------------------------===//
+
+static int runOpt(const std::string &in, const std::string &out) {
+  std::string cmd = "opt ";
+
+  // Preserve grouped levels (-O2, -O3), else use the new-PM pipeline
+  if (OptMode.rfind("-O", 0) == 0) {
+    cmd += OptMode + " ";
+  } else {
+    cmd += "-passes=" + OptMode + " ";
+  }
+
+  cmd += "-S " + in + " -o " + out;
+  return std::system(cmd.c_str());
+}
+
+//===----------------------------------------------------------------------===//
+// runDriver: front-end that emits unoptimized IR (via clang) then diffs it
+//===----------------------------------------------------------------------===//
+
+int runDriver(int argc, char **argv) {
+  // 1) Parse options
+  cl::ParseCommandLineOptions(argc, argv, "optviz - LLVM IR diff tool\n");
+
+  // 2) Compute base filename (strip extension)
+  std::string base = InputFile;
+  if (auto pos = base.rfind('.'); pos != std::string::npos)
+    base = base.substr(0, pos);
+
+  // 3) Emit IR if input is .cpp, else assume .ll
+  std::string srcIR = base + ".ll";
+  if (InputFile.size() >= 4 &&
+      InputFile.substr(InputFile.size() - 4) == ".cpp") {
+    std::string clangCmd =
+      "clang -S -emit-llvm " + InputFile + " -o " + srcIR;
+    if (std::system(clangCmd.c_str()) != 0) {
+      errs() << "Error: clang failed to emit LLVM IR for " << InputFile << "\n";
+      return 1;
+    }
+  } else {
+    srcIR = InputFile;
+  }
+
+  // 4) Run the requested opt pipeline
+  std::string optIR = base + ".opt.ll";
+  if (runOpt(srcIR, optIR) != 0) {
+    errs() << "Error: opt failed with mode '" << OptMode << "'\n";
+    return 1;
+  }
+
+  // 5) Diff the IR
+  int diffRet = runIRDiff(srcIR, optIR);
+
+  // 6) Optionally generate a GenAI summary of the diff
+  if (diffRet == 0 && GenAISummaries) {
+    outs() << "\n=== Auto-generated Summary ===\n\n";
+    // Calls your LLM-based summarizer: pass it the IR file paths
+    std::string summary = SummaryGen::summarize(srcIR, optIR);
+    outs() << summary << "\n";
+  }
+
+  return diffRet;
+}

--- a/llvm/tools/optviz/src/PassDriver.h
+++ b/llvm/tools/optviz/src/PassDriver.h
@@ -1,0 +1,10 @@
+// llvm/tools/optviz/include/PassDriver.h
+#pragma once
+
+#include <string>
+
+// Entry point called from main()
+int runDriver(int argc, char **argv);
+
+// IR-diff engine
+int runIRDiff(const std::string &before, const std::string &after);

--- a/llvm/tools/optviz/src/SummaryGen.cpp
+++ b/llvm/tools/optviz/src/SummaryGen.cpp
@@ -1,0 +1,97 @@
+// llvm/tools/optviz/src/SummaryGen.cpp
+
+#include "SummaryGen.h"
+#include <curl/curl.h>
+#include <nlohmann/json.hpp>
+#include <fstream>
+#include <sstream>
+#include <cstdlib>
+#include <llvm/Support/raw_ostream.h>
+
+using json = nlohmann::json;
+
+// libcurl callback: append data
+static size_t writeCallback(char *ptr, size_t size, size_t nmemb, void *userdata) {
+    size_t total = size * nmemb;
+    static_cast<std::string*>(userdata)->append(ptr, total);
+    return total;
+}
+
+// Read file into string
+static bool readFileToString(const std::string &path, std::string &out) {
+    std::ifstream in(path);
+    if (!in.is_open()) return false;
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    out = ss.str();
+    return true;
+}
+
+std::string SummaryGen::summarize(const std::string &beforePath,
+                                  const std::string &afterPath) {
+    // Load IR
+    std::string beforeIR, afterIR;
+    if (!readFileToString(beforePath, beforeIR) ||
+        !readFileToString(afterPath,  afterIR)) {
+        return "[Error: cannot read IR files]";
+    }
+
+    // Build prompt
+    std::string prompt =
+        "Summarize the change between two LLVM IR snippets, focusing on intent and performance:\n\n"
+        "BEFORE IR:\n" + beforeIR +
+        "\nAFTER IR:\n"  + afterIR +
+        "\n\nProvide a clear, concise explanation.";
+
+    // API key
+    const char *keyEnv = std::getenv("COHERE_API_KEY");
+    if (!keyEnv) return "[Error: COHERE_API_KEY not set]";
+    std::string apiKey(keyEnv);
+
+    // JSON payload
+    json body = {
+        {"model", "command"},
+        {"prompt", prompt},
+        {"max_tokens", 200},
+        {"temperature", 0.3}
+    };
+    std::string bodyStr = body.dump();
+
+    // HTTP POST
+    CURL *curl = curl_easy_init();
+    if (!curl) return "[Error: curl init failed]";
+    std::string response;
+    struct curl_slist *headers = nullptr;
+    headers = curl_slist_append(headers, ("Authorization: Bearer " + apiKey).c_str());
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://api.cohere.ai/generate");
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, bodyStr.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+    CURLcode res = curl_easy_perform(curl);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+    if (res != CURLE_OK) return "[Error: Cohere request failed]";
+
+    // Debug raw JSON
+    llvm::errs() << "=== Raw Cohere response ===\n" << response << "\n";
+
+    // Parse JSON
+    auto j = json::parse(response, nullptr, false);
+    if (j.is_discarded()) return "[Error: JSON parse failed]";
+
+    // Extract "text" field if present
+    if (j.contains("text") && j["text"].is_string()) {
+        std::string out = j["text"].get<std::string>();
+        // Trim whitespace
+        const auto ws = " \t\n\r";
+        size_t start = out.find_first_not_of(ws);
+        size_t end = out.find_last_not_of(ws);
+        if (start != std::string::npos && end != std::string::npos)
+            return out.substr(start, end - start + 1);
+        return out;
+    }
+
+    return "[Error: Unexpected API schema]";
+}

--- a/llvm/tools/optviz/src/SummaryGen.h
+++ b/llvm/tools/optviz/src/SummaryGen.h
@@ -1,0 +1,10 @@
+// llvm/tools/optviz/src/SummaryGen.h
+
+#pragma once
+#include <string>
+
+namespace SummaryGen {
+  // Sends the before/after IR snippet to an LLM and returns the summary.
+  std::string summarize(const std::string &beforeIR,
+                        const std::string &afterIR);
+}

--- a/llvm/tools/optviz/src/main.cpp
+++ b/llvm/tools/optviz/src/main.cpp
@@ -1,0 +1,4 @@
+#include "PassDriver.h"
+int main(int argc, char **argv) {
+  return runDriver(argc, argv);
+}


### PR DESCRIPTION
Closes #42

- Introduce `optviz` LLVM tool under `llvm/tools/optviz/`
- Add HTML-diff generator script (`generate_diff_html.py`)
- Integrate GenAI summaries via Cohere
- Update CMakeLists to find curl & nlohmann/json
- Include small example tests under `examples/`
<img width="1512" alt="Screenshot 2025-06-15 at 8 36 59 PM" src="https://github.com/user-attachments/assets/92fa7445-9dbc-41c6-a33a-394426068fca" />
![Uploading Screenshot 2025-06-15 at 8.38.32 PM.png…]()
