### PR TITLE
Issue #17 dump auto type inferences

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9362,7 +9362,8 @@ def note_building_builtin_dump_struct_call : Note<
   "in call to printing function with arguments '(%0)' while dumping struct">;
 def err_builtin_verbose_trap_arg : Error<
   "argument to __builtin_verbose_trap must %select{be a pointer to a constant string|not contain $}0">;
-
+def note_auto_type_deduced : Note<
+  "variable '%0' deduced to type '%1'">;
 def err_atomic_load_store_uses_lib : Error<
   "atomic %select{load|store}0 requires runtime support that is not "
   "available for this target">;

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -323,6 +323,7 @@ BENIGN_LANGOPT(DumpRecordLayoutsCanonical , 1, 0, "dumping the AST layout of rec
 BENIGN_LANGOPT(DumpRecordLayoutsComplete , 1, 0, "dumping the AST layout of all complete records")
 BENIGN_LANGOPT(DumpVTableLayouts , 1, 0, "dumping the layouts of emitted vtables")
 LANGOPT(NoConstantCFStrings , 1, 0, "no constant CoreFoundation strings")
+BENIGN_LANGOPT(DumpAutoTypeInference, 1, 0, "Dump type information inferred for 'auto' keyword including return types and NTTPs")
 BENIGN_LANGOPT(InlineVisibilityHidden , 1, 0, "hidden visibility for inline C++ methods")
 BENIGN_ENUM_LANGOPT(DefaultVisibilityExportMapping, DefaultVisiblityExportMapping, 2, DefaultVisiblityExportMapping::None, "controls mapping of default visibility to dllexport")
 BENIGN_LANGOPT(IgnoreXCOFFVisibility, 1, 0, "All the visibility attributes that are specified in the source code are ignored in aix XCOFF.")

--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -510,7 +510,8 @@ public:
   SanitizerSet Sanitize;
   /// Is at least one coverage instrumentation type enabled.
   bool SanitizeCoverage = false;
-
+  /// Initilizing flag to false
+  bool DumpAutoTypeInference = false;
   /// Paths to files specifying which objects
   /// (files, functions, variables) should not be instrumented.
   std::vector<std::string> NoSanitizeFiles;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -8180,6 +8180,9 @@ def fdump_record_layouts : Flag<["-"], "fdump-record-layouts">,
   HelpText<"Dump record layout information">,
   MarshallingInfoFlag<LangOpts<"DumpRecordLayouts">>,
   ImpliedByAnyOf<[fdump_record_layouts_simple.KeyPath, fdump_record_layouts_complete.KeyPath, fdump_record_layouts_canonical.KeyPath]>;
+def fdump_auto_type_inference : Flag<["-"], "fdump-auto-type-inference">,
+  HelpText<"Dump type information inferred for 'auto' keyword including return types and NTTPs">,
+  MarshallingInfoFlag<LangOpts<"DumpAutoTypeInference">>;
 def fix_what_you_can : Flag<["-"], "fix-what-you-can">,
   HelpText<"Apply fix-it advice even in the presence of unfixable errors">,
   MarshallingInfoFlag<FrontendOpts<"FixWhatYouCan">>;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -90,6 +90,7 @@
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -922,7 +922,14 @@ public:
 
   /// Print out statistics about the semantic analysis.
   void PrintStats() const;
-
+  /// Prints the auto inferences for auto variables, return types
+  void DumpAutoTypeInference(SourceManager &SM, SourceLocation Loc, bool isVar,
+                             ASTContext &Context, llvm::StringRef Name,
+                             QualType DeducedType);
+  /// Prints the auto inferences for NTTPs
+  void DumpNTTPTypeInference(SourceManager &SM, SourceLocation Loc,
+                           ASTContext &Context, llvm::StringRef Name,
+                           QualType DeducedType);
   /// Run some code with "sufficient" stack space. (Currently, at least 256K is
   /// guaranteed). Produces a warning if we're low on stack space and allocates
   /// more in that case. Use this in code that may recurse deeply (for example,

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13157,9 +13157,16 @@ bool Sema::DeduceVariableDeclarationType(VarDecl *VDecl, bool DirectInit,
     return true;
   }
 
+  // Calling DumpAutoTypeInference for auto inference
+  if (getLangOpts().DumpAutoTypeInference &&
+      isa<AutoType>(VDecl->getType().getTypePtr())) {
+    DumpAutoTypeInference(getSourceManager(), VDecl->getLocation(),
+                          true, Context, VDecl->getNameAsString(),
+                          DeducedType);
+  }
   VDecl->setType(DeducedType);
   assert(VDecl->isLinkageValid());
-
+  
   // In ARC, infer lifetime.
   if (getLangOpts().ObjCAutoRefCount && ObjC().inferObjCARCLifetime(VDecl))
     VDecl->setInvalidDecl();

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3833,7 +3833,9 @@ bool Sema::DeduceFunctionTypeFromReturnExpr(FunctionDecl *FD,
   if (!FD->isInvalidDecl() && AT->getDeducedType() != Deduced)
     // Update all declarations of the function to have the deduced return type.
     Context.adjustDeducedFunctionResultType(FD, Deduced);
-
+  SourceManager &SM = getSourceManager();
+  Sema::DumpAutoTypeInference(SM, FD->getLocation(), false, Context,
+                              FD->getNameAsString(), Deduced);
   return false;
 }
 

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -6941,7 +6941,14 @@ ExprResult Sema::CheckTemplateArgument(NonTypeTemplateParmDecl *Param,
       Arg = DeductionArg;
     }
   };
-
+  // Calling DumpNTTPTypeInference for auto NTTPs inference
+  if (getLangOpts().DumpAutoTypeInference && Param && !Param->getName().empty()) {
+    QualType DeducedTy = Arg->getType();
+    if (!DeducedTy.isNull()) {
+      DumpNTTPTypeInference(getSourceManager(), Arg->getExprLoc(), Context,
+                            Param->getName(), DeducedTy);
+    }
+  }
   // If the parameter type somehow involves auto, deduce the type now.
   DeducedType *DeducedT = ParamType->getContainedDeducedType();
   if (getLangOpts().CPlusPlus17 && DeducedT && !DeducedT->isDeduced()) {

--- a/clang/test/Sema/dump-auto-type-inference.cpp
+++ b/clang/test/Sema/dump-auto-type-inference.cpp
@@ -1,0 +1,72 @@
+#include <vector>
+#include <string>
+#include <map>
+#include <list>
+#include <utility>
+
+auto int_var = 42;
+
+auto double_var = 3.14;
+
+auto char_var = 'a';
+
+const auto const_var = 10;
+
+auto& ref_var = int_var;
+
+const auto& const_ref_var = double_var;
+
+
+std::vector<int> vec;
+auto vec_it = vec.begin();
+
+std::string str = "hello";
+auto str_it = str.begin();
+
+std::map<int, std::string> m;
+auto map_it = m.begin();
+
+std::list<double> lst;
+auto lst_it = lst.begin();
+
+auto int_func() { return 42; }
+
+auto string_func() { return std::string("test"); }
+
+template<typename T>
+auto template_func(T t) { return t; }
+
+template<auto N>
+struct ValueHolder {};
+
+ValueHolder<5> int_holder;
+
+ValueHolder<3.14> double_holder;
+
+ValueHolder<'c'> char_holder;
+
+template<auto* P>
+struct PointerHolder {};
+
+int int_val = 10;
+PointerHolder<&int_val> ptr_holder;
+
+auto lambda = [](int x) { return x * 2; };
+
+auto capturing_lambda = [](auto x) { return x + int_var; };
+
+decltype(auto) decltype_var = int_var;
+
+auto sys_vec = std::vector<float>();
+
+auto complex_expr = 1 + 2.0 * 3;
+
+template<typename... Ts>
+auto sum(Ts... args) { return (args + ...); }
+
+template<typename T>
+auto sfinae_func(T t) -> decltype(t.begin()) { return t.begin(); }
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
Implements feature request #17: Adds a new compiler option to Clang that emits informational messages describing the type deduced for each use of the auto keyword in C++11 and later. Also covers function return types and non-type template parameters. Specific functionalities like NTTPs are limited to stdc++17 and beyond.

For getting the required output on the test file llvm-project\clang\test\Sema\dump-auto-type-inference.cpp, 
Run:

```bash
> install\bin\clang++ -std=c++20 -Xclang -fdump-auto-type-inference clang\test\Sema\dump-auto-type-inference.cpp
```
from project folder. Flag -std=c++20 is used as it supports features not available in the lower versions. The output is:

```text
clang\test\Sema\dump-auto-type-inference.cpp:7:6: note: type of 'int_var' deduced as 'int'
clang\test\Sema\dump-auto-type-inference.cpp:9:6: note: type of 'double_var' deduced as 'double'
clang\test\Sema\dump-auto-type-inference.cpp:11:6: note: type of 'char_var' deduced as 'char'
clang\test\Sema\dump-auto-type-inference.cpp:13:12: note: type of 'const_var' deduced as 'const int'
clang\test\Sema\dump-auto-type-inference.cpp:21:6: note: type of 'vec_it' deduced as 'std::_Vector_iterator<std::_Vector_val<std::_Simple_types<int>>>'
clang\test\Sema\dump-auto-type-inference.cpp:24:6: note: type of 'str_it' deduced as 'std::_String_iterator<std::_String_val<std::_Simple_types<char>>>'
clang\test\Sema\dump-auto-type-inference.cpp:27:6: note: type of 'map_it' deduced as 'std::_Tree_iterator<std::_Tree_val<std::_Tree_simple_types<std::pair<const int, std::basic_string<char>>>>>'
clang\test\Sema\dump-auto-type-inference.cpp:30:6: note: type of 'lst_it' deduced as 'std::_List_iterator<std::_List_val<std::_List_simple_types<double>>>'
clang\test\Sema\dump-auto-type-inference.cpp:32:6: note: type of 'int_func' deduced as 'int'
clang\test\Sema\dump-auto-type-inference.cpp:34:6: note: type of 'string_func' deduced as 'std::basic_string<char>'
clang\test\Sema\dump-auto-type-inference.cpp:42:13: note: NTTP 'N' deduced as 'int'
clang\test\Sema\dump-auto-type-inference.cpp:44:13: note: NTTP 'N' deduced as 'double'
clang\test\Sema\dump-auto-type-inference.cpp:46:13: note: NTTP 'N' deduced as 'char'
clang\test\Sema\dump-auto-type-inference.cpp:52:15: note: NTTP 'P' deduced as 'int *'
clang\test\Sema\dump-auto-type-inference.cpp:54:15: note: type of 'operator()' deduced as 'int'
clang\test\Sema\dump-auto-type-inference.cpp:54:6: note: type of 'lambda' deduced as '(lambda at clang/test/Sema/dump-auto-type-inference.cpp:54:15)'
clang\test\Sema\dump-auto-type-inference.cpp:56:6: note: type of 'capturing_lambda' deduced as '(lambda at clang/test/Sema/dump-auto-type-inference.cpp:56:25)'
clang\test\Sema\dump-auto-type-inference.cpp:58:16: note: type of 'decltype_var' deduced as 'int'
clang\test\Sema\dump-auto-type-inference.cpp:60:6: note: type of 'sys_vec' deduced as 'std::vector<float>'
clang\test\Sema\dump-auto-type-inference.cpp:62:6: note: type of 'complex_expr' deduced as 'double'
```
