### PR TITLE
Implement __fq_func__ and __mangled_func__ identifiers for Clang (#5)

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -2004,7 +2004,9 @@ enum class PredefinedIdentKind {
   PrettyFunction,
   /// The same as PrettyFunction, except that the
   /// 'virtual' keyword is omitted for virtual member functions.
-  PrettyFunctionNoVirtual
+  PrettyFunctionNoVirtual,
+  FQFunction,
+  MangledFunction
 };
 
 /// [C99 6.4.2.2] - A predefined identifier such as __func__.

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -1,4 +1,51 @@
-//===--- Expr.cpp - Expression AST Node Implementation --------------------===//
+// ...existing code...
+StringRef PredefinedExpr::getIdentKindName(PredefinedIdentKind IK) {
+  switch (IK) {
+  case PredefinedIdentKind::Func:
+    return "__func__";
+  case PredefinedIdentKind::Function:
+    return "__FUNCTION__";
+  case PredefinedIdentKind::FuncDName:
+    return "__FUNCDNAME__";
+  case PredefinedIdentKind::FQFunction:
+    return "__fq_func__";
+  case PredefinedIdentKind::MangledFunction:
+    return "__mangled_func__";
+  case PredefinedIdentKind::LFunction:
+    return "L__FUNCTION__";
+  case PredefinedIdentKind::PrettyFunction:
+    return "__PRETTY_FUNCTION__";
+  case PredefinedIdentKind::FuncSig:
+    return "__FUNCSIG__";
+  case PredefinedIdentKind::LFuncSig:
+    return "L__FUNCSIG__";
+  case PredefinedIdentKind::PrettyFunctionNoVirtual:
+    break;
+  }
+  llvm_unreachable("Unknown ident kind for PredefinedExpr");
+}
+// ...existing code...
+std::string PredefinedExpr::ComputeName(PredefinedIdentKind IK,
+                                        const Decl *CurrentDecl,
+                                        bool ForceElaboratedPrinting) {
+  ASTContext &Context = CurrentDecl->getASTContext();
+
+  if (IK == PredefinedIdentKind::FQFunction) {
+    if (const auto *ND = dyn_cast<NamedDecl>(CurrentDecl))
+      return ND->getQualifiedNameAsString();
+    return "<unknown>";
+  }
+
+  if (IK == PredefinedIdentKind::MangledFunction) {
+    if (const auto *ND = dyn_cast<NamedDecl>(CurrentDecl)) {
+      std::unique_ptr<MangleContext> MC;
+      MC.reset(Context.createMangleContext());
+      SmallString<256> Buffer;
+      llvm::raw_svector_ostream Out(Buffer);
+      GlobalDecl GD;
+      if (const CXXConstructorDecl *CD = dyn_cast<CXXConstructorDecl>(ND))
+        GD = GlobalDecl(CD, Ctor_Base);
+      else//===--- Expr.cpp - Expression AST Node Implementation --------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -653,6 +700,104 @@ StringRef PredefinedExpr::getIdentKindName(PredefinedIdentKind IK) {
     return "__FUNCTION__";
   case PredefinedIdentKind::FuncDName:
     return "__FUNCDNAME__";
+    // ...existing code...
+  StringRef PredefinedExpr::getIdentKindName(PredefinedIdentKind IK) {
+    switch (IK) {
+    case PredefinedIdentKind::Func:
+      return "__func__";
+    case PredefinedIdentKind::Function:
+      return "__FUNCTION__";
+    case PredefinedIdentKind::FuncDName:
+      return "__FUNCDNAME__";
+    case PredefinedIdentKind::FQFunction:
+      return "__fq_func__";
+    case PredefinedIdentKind::MangledFunction:
+      return "__mangled_func__";
+    case PredefinedIdentKind::LFunction:
+      return "L__FUNCTION__";
+    case PredefinedIdentKind::PrettyFunction:
+      return "__PRETTY_FUNCTION__";
+    case PredefinedIdentKind::FuncSig:
+      return "__FUNCSIG__";
+    case PredefinedIdentKind::LFuncSig:
+      return "L__FUNCSIG__";
+    case PredefinedIdentKind::PrettyFunctionNoVirtual:
+      break;
+    }
+    llvm_unreachable("Unknown ident kind for PredefinedExpr");
+  }
+  // ...existing code...
+  std::string PredefinedExpr::ComputeName(PredefinedIdentKind IK,
+                                          const Decl *CurrentDecl,
+                                          bool ForceElaboratedPrinting) {                                          // ...existing code...
+                                          StringRef PredefinedExpr::getIdentKindName(PredefinedIdentKind IK) {
+                                            switch (IK) {
+                                            case PredefinedIdentKind::Func:
+                                              return "__func__";
+                                            case PredefinedIdentKind::Function:
+                                              return "__FUNCTION__";
+                                            case PredefinedIdentKind::FuncDName:
+                                              return "__FUNCDNAME__";
+                                            case PredefinedIdentKind::FQFunction:
+                                              return "__fq_func__";
+                                            case PredefinedIdentKind::MangledFunction:
+                                              return "__mangled_func__";
+                                            case PredefinedIdentKind::LFunction:
+                                              return "L__FUNCTION__";
+                                            case PredefinedIdentKind::PrettyFunction:
+                                              return "__PRETTY_FUNCTION__";
+                                            case PredefinedIdentKind::FuncSig:
+                                              return "__FUNCSIG__";
+                                            case PredefinedIdentKind::LFuncSig:
+                                              return "L__FUNCSIG__";
+                                            case PredefinedIdentKind::PrettyFunctionNoVirtual:
+                                              break;
+                                            }
+                                            llvm_unreachable("Unknown ident kind for PredefinedExpr");
+                                          }
+                                          // ...existing code...
+                                          std::string PredefinedExpr::ComputeName(PredefinedIdentKind IK,
+                                                                                  const Decl *CurrentDecl,
+                                                                                  bool ForceElaboratedPrinting) {
+                                            ASTContext &Context = CurrentDecl->getASTContext();
+                                          
+                                            if (IK == PredefinedIdentKind::FQFunction) {
+                                              if (const auto *ND = dyn_cast<NamedDecl>(CurrentDecl))
+                                                return ND->getQualifiedNameAsString();
+                                              return "<unknown>";
+                                            }
+                                          
+                                            if (IK == PredefinedIdentKind::MangledFunction) {
+                                              if (const auto *ND = dyn_cast<NamedDecl>(CurrentDecl)) {
+                                                std::unique_ptr<MangleContext> MC;
+                                                MC.reset(Context.createMangleContext());
+                                                SmallString<256> Buffer;
+                                                llvm::raw_svector_ostream Out(Buffer);
+                                                GlobalDecl GD;
+                                                if (const CXXConstructorDecl *CD = dyn_cast<CXXConstructorDecl>(ND))
+                                                  GD = GlobalDecl(CD, Ctor_Base);
+                                                else
+    ASTContext &Context = CurrentDecl->getASTContext();
+  
+    if (IK == PredefinedIdentKind::FQFunction) {
+      if (const auto *ND = dyn_cast<NamedDecl>(CurrentDecl))
+        return ND->getQualifiedNameAsString();
+      return "<unknown>";
+    }
+  
+    if (IK == PredefinedIdentKind::MangledFunction) {
+      if (const auto *ND = dyn_cast<NamedDecl>(CurrentDecl)) {
+        std::unique_ptr<MangleContext> MC;
+        MC.reset(Context.createMangleContext());
+        SmallString<256> Buffer;
+        llvm::raw_svector_ostream Out(Buffer);
+        GlobalDecl GD;
+        if (const CXXConstructorDecl *CD = dyn_cast<CXXConstructorDecl>(ND))
+          GD = GlobalDecl(CD, Ctor_Base);
+        elsecase PredefinedIdentKind::FQFunction:
+    return "__fq_func__";
+  case PredefinedIdentKind::MangledFunction:
+    return "__mangled_func__";
   case PredefinedIdentKind::LFunction:
     return "L__FUNCTION__";
   case PredefinedIdentKind::PrettyFunction:

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -2002,7 +2002,11 @@ static PredefinedIdentKind getPredefinedExprKind(tok::TokenKind Kind) {
   default:
     llvm_unreachable("unexpected TokenKind");
   case tok::kw___func__:
-    return PredefinedIdentKind::Func; // [C99 6.4.2.2]
+    return PredefinedIdentKind::Func;
+  case tok::kw___fq_func__:
+    return PredefinedIdentKind::FQFunction;
+  case tok::kw___mangled_func__:
+    return PredefinedIdentKind::MangledFunction; // [C99 6.4.2.2]
   case tok::kw___FUNCTION__:
     return PredefinedIdentKind::Function;
   case tok::kw___FUNCDNAME__:


### PR DESCRIPTION
Extending LLVM and Clang to support new identifiers (fq_func, mangled_func) for retrieving fully qualified and mangled names of functions.

