### PR TITLE
Fixes #19: Dump lexical extents of function definitions

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -9313,3 +9313,6 @@ def wasm_opt : Flag<["--"], "wasm-opt">,
   Group<m_Group>,
   HelpText<"Enable the wasm-opt optimizer (default)">,
   MarshallingInfoNegativeFlag<LangOpts<"NoWasmOpt">>;
+def fdump_function_extents : Flag<["-"], "fdump-function-extents">,
+  HelpText<"Dump function extents">,
+  Visibility<[CC1Option]>;

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -279,6 +279,9 @@ public:
   LLVM_PREFERRED_TYPE(bool)
   unsigned DisableFree : 1;
 
+  /// Dump Function Extents Variable 
+  bool DumpFunctionExtents = false;
+
   /// When generating PCH files, instruct the AST writer to create relocatable
   /// PCH files.
   LLVM_PREFERRED_TYPE(bool)

--- a/clang/include/clang/Frontend/FunctionExtentConsumer.h
+++ b/clang/include/clang/Frontend/FunctionExtentConsumer.h
@@ -1,0 +1,27 @@
+#ifndef LLVM_CLANG_FRONTEND_FUNCTIONEXTENTPLUGIN_H
+#define LLVM_CLANG_FRONTEND_FUNCTIONEXTENTPLUGIN_H
+
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/AST/ASTConsumer.h"
+#include <memory>
+
+namespace clang {
+
+class FunctionExtentConsumer : public ASTConsumer {
+    ASTContext *Context = nullptr;
+public:
+  void Initialize(ASTContext &Ctx) override;
+  void HandleTranslationUnit(ASTContext &Ctx) override;
+};
+
+class FunctionExtentAction : public PluginASTAction {
+protected:
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
+                                                 llvm::StringRef) override;
+  bool ParseArgs(const CompilerInstance &CI,
+                 const std::vector<std::string> &) override;
+};
+
+} // namespace clang
+
+#endif // LLVM_CLANG_FRONTEND_FUNCTIONEXTENTPLUGIN_H

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2976,6 +2976,14 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
 
   FrontendOptions &FrontendOpts = Opts;
 
+  if (Args.hasArg(OPT_fdump_function_extents)) {
+    Opts.DumpFunctionExtents = true;
+  }
+
+  if (Opts.DumpFunctionExtents){
+    Opts.AddPluginActions.push_back("dump-function-extents");
+  }
+
 #define FRONTEND_OPTION_WITH_MARSHALLING(...)                                  \
   PARSE_OPTION_WITH_MARSHALLING(Args, Diags, __VA_ARGS__)
 #include "clang/Driver/Options.inc"

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -28,6 +28,7 @@
 #include "clang/Frontend/MultiplexConsumer.h"
 #include "clang/Frontend/SARIFDiagnosticPrinter.h"
 #include "clang/Frontend/Utils.h"
+#include "clang/Frontend/FunctionExtentConsumer.h"
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/LiteralSupport.h"
 #include "clang/Lex/Preprocessor.h"
@@ -302,6 +303,11 @@ FrontendAction::CreateWrappedASTConsumer(CompilerInstance &CI,
     return nullptr;
 
   std::vector<std::unique_ptr<ASTConsumer>> Consumers;
+
+  if (CI.getFrontendOpts().DumpFunctionExtents) {
+    Consumers.push_back(std::make_unique<FunctionExtentConsumer>());
+  }
+
   llvm::StringRef DumpDeserializedDeclarationRangesPath =
       CI.getFrontendOpts().DumpMinimizationHintsPath;
   if (!DumpDeserializedDeclarationRangesPath.empty()) {

--- a/clang/lib/Frontend/FunctionExtentConsumer.cpp
+++ b/clang/lib/Frontend/FunctionExtentConsumer.cpp
@@ -1,0 +1,53 @@
+#include "clang/Frontend/FunctionExtentConsumer.h"
+#include "clang/AST/Decl.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Basic/SourceManager.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace clang;
+
+void FunctionExtentConsumer::Initialize(ASTContext &Ctx) {
+  Context = &Ctx;
+}
+
+void FunctionExtentConsumer::HandleTranslationUnit(ASTContext &Ctx) {
+  SourceManager &SM = Ctx.getSourceManager();
+
+  for (Decl *D : Ctx.getTranslationUnitDecl()->decls()) {
+    if (auto *FD = dyn_cast<FunctionDecl>(D)) {
+      if (!FD->hasBody())
+        continue;
+
+      SourceLocation BeginLoc = FD->getSourceRange().getBegin();
+      SourceLocation EndLoc = FD->getSourceRange().getEnd();
+
+      PresumedLoc PBegin = SM.getPresumedLoc(BeginLoc);
+      PresumedLoc PEnd = SM.getPresumedLoc(EndLoc);
+
+      if (PBegin.isInvalid() || PEnd.isInvalid())
+        continue;
+
+      llvm::outs() << FD->getQualifiedNameAsString()
+                   << ":" << PBegin.getFilename()
+                   << ":" << PBegin.getLine()
+                   << "-" << PEnd.getLine()
+                   << "\n";
+      // <QualifiedFunctionName>:<Filename>:<StartLine>-<EndLine>
+    }
+  }
+}
+
+std::unique_ptr<ASTConsumer>
+FunctionExtentAction::CreateASTConsumer(CompilerInstance &CI,
+                                        llvm::StringRef) {
+  return std::make_unique<FunctionExtentConsumer>();
+}
+
+bool FunctionExtentAction::ParseArgs(const CompilerInstance &CI,
+                                     const std::vector<std::string> &) {
+  return true;
+}
+
+// Register the plugin
+static FrontendPluginRegistry::Add<FunctionExtentAction>
+    X("dump-function-extents", "Dump lexical extents of functions");


### PR DESCRIPTION
# Add `dump-function-extents` Clang Plugin and `-fdump-function-extents` Flag

## Description

This pull request introduces a new **Clang plugin** named `dump-function-extents`, along with support for a custom `-fdump-function-extents` flag. The plugin traverses the AST and prints the **lexical source extents (line range)** of each function definition in the input source file.

---

## Implementation Details

### New Functionality:
- **Plugin name**: `dump-function-extents`
- **Compiler flag**: `-fdump-function-extents` (usable with `-cc1`)
- **Output format**:
  ```
  <qualified-function-name>:<file-name>:<start-line>-<end-line>
  ```

### Internal Changes:
- Created plugin logic in `FunctionExtentConsumer.cpp`, walking the AST for `FunctionDecl`s.
- Registered the plugin via `FrontendPluginRegistry`.
- Parsed new flag inside `CompilerInvocation.cpp`:
  ```cpp
  if (Args.hasArg(OPT_fdump_function_extents)) {
    Opts.DumpFunctionExtents = true;
  }
  if (Opts.DumpFunctionExtents) {
    Opts.AddPluginActions.push_back("dump-function-extents");
  }
  ```
- Declared the flag in `Options.td`:
  ```td
  def fdump_function_extents : Flag<["-"], "fdump-function-extents">,
    HelpText<"Dump function extents">,
    Visibility<[CC1Option]>;
  ```

---

## Files Changed

- `clang/lib/Frontend/FunctionExtentConsumer.cpp`
- `clang/include/clang/Frontend/FunctionExtentConsumer.h`
- `clang/lib/Frontend/CompilerInvocation.cpp`
- `clang/include/clang/Frontend/FrontendOptions.h`
- `clang/include/clang/Driver/Options.td`

---

## Example Output

Given the input file:

```cpp
void foo() {
  int x = 0;
}

void bar() {
  int y = 1;
}
```

Running:

```sh
clang -cc1 -fdump-function-extents test.cpp
```

Outputs:

```
foo:test.cpp:1-3
bar:test.cpp:5-7
```

---

## Testing

- Manually tested with `clang -cc1 -fdump-function-extents input.cpp`
- Verified plugin activation via both `-add-plugin` and custom flag

---

Let me know if additional tests or integration steps are needed!
