### PR TITLE
Add function scope identifier

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -879,6 +879,8 @@ if (LLVM_ADD_NATIVE_VISUALIZERS_TO_SOLUTION)
 endif()
 add_subdirectory(utils/hmaptool)
 
+
+
 if(CLANG_BUILT_STANDALONE)
   llvm_distribution_add_targets()
   process_llvm_pass_plugins()
@@ -889,3 +891,5 @@ set(CLANG_INSTALL_LIBDIR_BASENAME "lib${CLANG_LIBDIR_SUFFIX}")
 configure_file(
   ${CLANG_SOURCE_DIR}/include/clang/Config/config.h.cmake
   ${CLANG_BINARY_DIR}/include/clang/Config/config.h)
+
+

--- a/clang/tools/CMakeLists.txt
+++ b/clang/tools/CMakeLists.txt
@@ -52,3 +52,5 @@ add_llvm_external_project(clang-tools-extra extra)
 add_clang_subdirectory(libclang)
 
 add_clang_subdirectory(offload-arch)
+
+add_clang_subdirectory(FunctionScopeIdentifier)

--- a/clang/tools/FunctionScopeIdentifier/CMakeLists.txt
+++ b/clang/tools/FunctionScopeIdentifier/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_clang_executable(FunctionScopeIdentifier
+  FunctionScopeIdentifier.cpp
+)
+
+target_link_libraries(FunctionScopeIdentifier
+  PRIVATE
+  clangTooling
+  clangBasic
+  clangASTMatchers
+)

--- a/clang/tools/FunctionScopeIdentifier/FunctionScopeIdentifier.cpp
+++ b/clang/tools/FunctionScopeIdentifier/FunctionScopeIdentifier.cpp
@@ -1,0 +1,117 @@
+#include "clang/Tooling/CommonOptionsParser.h"
+#include "clang/Tooling/Tooling.h"
+#include "clang/Frontend/FrontendActions.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "llvm/Support/CommandLine.h"
+#include <map>
+#include <set>
+#include <sstream>
+
+using namespace clang;
+using namespace clang::tooling;
+using namespace llvm;
+using namespace clang::ast_matchers;
+
+// Create an option category for the tool
+static cl::OptionCategory MyToolCategory("function-scope-identifier options");
+
+// Command-line option for line ranges
+static cl::opt<std::string> IdentifyRange(
+    "identify-scope-range",
+    cl::desc("Comma-separated list of line ranges (e.g., 5-10,15-20)"),
+    cl::value_desc("line-ranges"),
+    cl::Required,
+    cl::cat(MyToolCategory));
+
+// Parse line range string like "5-10,15-20" into vector of pairs
+std::vector<std::pair<unsigned, unsigned>> parseRanges(const std::string &rangeStr) {
+    std::vector<std::pair<unsigned, unsigned>> ranges;
+    std::stringstream ss(rangeStr);
+    std::string part;
+    while (std::getline(ss, part, ',')) {
+        auto dash = part.find('-');
+        if (dash != std::string::npos) {
+            unsigned start = std::stoi(part.substr(0, dash));
+            unsigned end = std::stoi(part.substr(dash + 1));
+            ranges.emplace_back(start, end);
+        }
+    }
+    return ranges;
+}
+
+// AST matcher callback
+class FunctionVisitor : public MatchFinder::MatchCallback {
+    SourceManager *SM;
+    std::vector<std::pair<unsigned, unsigned>> TargetRanges;
+
+public:
+    FunctionVisitor(SourceManager *SM, std::vector<std::pair<unsigned, unsigned>> Ranges)
+        : SM(SM), TargetRanges(Ranges) {}
+
+    void run(const MatchFinder::MatchResult &Result) override {
+        const FunctionDecl *FD = Result.Nodes.getNodeAs<FunctionDecl>("func");
+        if (!FD || !FD->hasBody()) return;
+
+        SourceLocation startLoc = FD->getBeginLoc();
+        SourceLocation endLoc = FD->getEndLoc();
+
+        unsigned startLine = SM->getSpellingLineNumber(startLoc);
+        unsigned endLine = SM->getSpellingLineNumber(endLoc);
+
+        for (auto &[rangeStart, rangeEnd] : TargetRanges) {
+            if (rangeEnd < startLine || rangeStart > endLine) continue;
+
+            llvm::outs() << "Range " << rangeStart << "-" << rangeEnd << ":\n";
+            llvm::outs() << "Function: " << FD->getNameInfo().getName().getAsString() << "\n";
+            llvm::outs() << "Start Line: " << startLine << "\n";
+            llvm::outs() << "End Line: " << endLine << "\n\n";
+        }
+    }
+};
+
+// FrontendAction to wrap matchers
+class ScopeFrontendAction : public ASTFrontendAction {
+public:
+    std::vector<std::pair<unsigned, unsigned>> Ranges;
+
+    ScopeFrontendAction(std::vector<std::pair<unsigned, unsigned>> R) : Ranges(R) {}
+
+    std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
+                                                   StringRef InFile) override {
+        auto *Finder = new MatchFinder();
+        auto *Callback = new FunctionVisitor(&CI.getSourceManager(), Ranges);
+
+        Finder->addMatcher(functionDecl(isExpansionInMainFile()).bind("func"), Callback);
+        return Finder->newASTConsumer();
+    }
+};
+
+// Factory to create ScopeFrontendAction with arguments
+class ScopeActionFactory : public FrontendActionFactory {
+    std::vector<std::pair<unsigned, unsigned>> Ranges;
+
+public:
+    ScopeActionFactory(std::vector<std::pair<unsigned, unsigned>> R) : Ranges(R) {}
+
+    std::unique_ptr<FrontendAction> create() override {
+        return std::make_unique<ScopeFrontendAction>(Ranges);
+    }
+};
+
+int main(int argc, const char **argv) {
+    auto ExpectedParser = CommonOptionsParser::create(argc, argv, MyToolCategory);
+    if (!ExpectedParser) {
+        llvm::errs() << ExpectedParser.takeError();
+        return 1;
+    }
+
+    CommonOptionsParser &OptionsParser = ExpectedParser.get();
+    ClangTool Tool(OptionsParser.getCompilations(), OptionsParser.getSourcePathList());
+
+    std::vector<std::pair<unsigned, unsigned>> ranges = parseRanges(IdentifyRange);
+    return Tool.run(new ScopeActionFactory(ranges));
+}
+  

--- a/test-files/test.cpp
+++ b/test-files/test.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+
+void foo() { std::cout << "foo\n"; }
+
+void bar() { std::cout << "bar\n"; }
+
+int main() {
+  foo();
+  bar();
+  return 0;
+}

--- a/test-files/test.ll
+++ b/test-files/test.ll
@@ -1,0 +1,1005 @@
+; ModuleID = 'test.cpp'
+source_filename = "test.cpp"
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "arm64-apple-macosx15.0.0"
+
+%"class.std::__1::basic_ostream" = type { ptr, %"class.std::__1::basic_ios.base" }
+%"class.std::__1::basic_ios.base" = type <{ %"class.std::__1::ios_base", ptr, %"struct.std::__1::_SentinelValueFill" }>
+%"class.std::__1::ios_base" = type { ptr, i32, i64, i64, i32, i32, ptr, ptr, ptr, ptr, i64, i64, ptr, i64, i64, ptr, i64, i64 }
+%"struct.std::__1::_SentinelValueFill" = type { i32 }
+%"class.std::__1::locale::id" = type <{ %"struct.std::__1::once_flag", i32, [4 x i8] }>
+%"struct.std::__1::once_flag" = type { i64 }
+%"class.std::__1::basic_ostream<char>::sentry" = type { i8, ptr }
+%"class.std::__1::ostreambuf_iterator" = type { ptr }
+%"class.std::__1::basic_string" = type { %"class.std::__1::__compressed_pair" }
+%"class.std::__1::__compressed_pair" = type { %"struct.std::__1::__compressed_pair_elem" }
+%"struct.std::__1::__compressed_pair_elem" = type { %"union.std::__1::basic_string<char>::__rep" }
+%"union.std::__1::basic_string<char>::__rep" = type { %"struct.std::__1::basic_string<char>::__long" }
+%"struct.std::__1::basic_string<char>::__long" = type { ptr, i64, i64 }
+%"class.std::__1::basic_ios" = type <{ %"class.std::__1::ios_base", ptr, %"struct.std::__1::_SentinelValueFill", [4 x i8] }>
+%"struct.std::__1::__default_init_tag" = type { i8 }
+%"struct.std::__1::basic_string<char>::__short" = type { [23 x i8], [0 x i8], i8 }
+%"class.std::__1::locale" = type { ptr }
+
+@_ZNSt3__14coutE = external global %"class.std::__1::basic_ostream", align 8
+@.str = private unnamed_addr constant [5 x i8] c"foo\0A\00", align 1
+@.str.1 = private unnamed_addr constant [5 x i8] c"bar\0A\00", align 1
+@_ZNSt3__15ctypeIcE2idE = external global %"class.std::__1::locale::id", align 8
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define void @_Z3foov() #0 {
+  %1 = call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSt3__1lsB8ne190102INS_11char_traitsIcEEEERNS_13basic_ostreamIcT_EES6_PKc(ptr noundef nonnull align 8 dereferenceable(8) @_ZNSt3__14coutE, ptr noundef @.str)
+  ret void
+}
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr hidden noundef nonnull align 8 dereferenceable(8) ptr @_ZNSt3__1lsB8ne190102INS_11char_traitsIcEEEERNS_13basic_ostreamIcT_EES6_PKc(ptr noundef nonnull align 8 dereferenceable(8) %0, ptr noundef %1) #0 {
+  %3 = alloca ptr, align 8
+  %4 = alloca ptr, align 8
+  store ptr %0, ptr %3, align 8
+  store ptr %1, ptr %4, align 8
+  %5 = load ptr, ptr %3, align 8
+  %6 = load ptr, ptr %4, align 8
+  %7 = load ptr, ptr %4, align 8
+  %8 = call i64 @_ZNSt3__111char_traitsIcE6lengthB8ne190102EPKc(ptr noundef %7) #7
+  %9 = call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSt3__124__put_character_sequenceB8ne190102IcNS_11char_traitsIcEEEERNS_13basic_ostreamIT_T0_EES7_PKS4_m(ptr noundef nonnull align 8 dereferenceable(8) %5, ptr noundef %6, i64 noundef %8)
+  ret ptr %9
+}
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define void @_Z3barv() #0 {
+  %1 = call noundef nonnull align 8 dereferenceable(8) ptr @_ZNSt3__1lsB8ne190102INS_11char_traitsIcEEEERNS_13basic_ostreamIcT_EES6_PKc(ptr noundef nonnull align 8 dereferenceable(8) @_ZNSt3__14coutE, ptr noundef @.str.1)
+  ret void
+}
+
+; Function Attrs: mustprogress noinline norecurse optnone ssp uwtable(sync)
+define i32 @main() #1 {
+  %1 = alloca i32, align 4
+  store i32 0, ptr %1, align 4
+  call void @_Z3foov()
+  call void @_Z3barv()
+  ret i32 0
+}
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr hidden noundef nonnull align 8 dereferenceable(8) ptr @_ZNSt3__124__put_character_sequenceB8ne190102IcNS_11char_traitsIcEEEERNS_13basic_ostreamIT_T0_EES7_PKS4_m(ptr noundef nonnull align 8 dereferenceable(8) %0, ptr noundef %1, i64 noundef %2) #0 personality ptr @__gxx_personality_v0 {
+  %4 = alloca ptr, align 8
+  %5 = alloca ptr, align 8
+  %6 = alloca i64, align 8
+  %7 = alloca %"class.std::__1::basic_ostream<char>::sentry", align 8
+  %8 = alloca ptr, align 8
+  %9 = alloca i32, align 4
+  %10 = alloca %"class.std::__1::ostreambuf_iterator", align 8
+  %11 = alloca %"class.std::__1::ostreambuf_iterator", align 8
+  store ptr %0, ptr %4, align 8
+  store ptr %1, ptr %5, align 8
+  store i64 %2, ptr %6, align 8
+  %12 = load ptr, ptr %4, align 8
+  %13 = invoke ptr @_ZNSt3__113basic_ostreamIcNS_11char_traitsIcEEE6sentryC1ERS3_(ptr noundef %7, ptr noundef nonnull align 8 dereferenceable(8) %12)
+          to label %14 unwind label %68
+
+14:                                               ; preds = %3
+  %15 = invoke zeroext i1 @_ZNKSt3__113basic_ostreamIcNS_11char_traitsIcEEE6sentrycvbB8ne190102Ev(ptr noundef %7)
+          to label %16 unwind label %72
+
+16:                                               ; preds = %14
+  br i1 %15, label %17, label %89
+
+17:                                               ; preds = %16
+  %18 = load ptr, ptr %4, align 8
+  %19 = call ptr @_ZNSt3__119ostreambuf_iteratorIcNS_11char_traitsIcEEEC1B8ne190102ERNS_13basic_ostreamIcS2_EE(ptr noundef %11, ptr noundef nonnull align 8 dereferenceable(8) %18) #7
+  %20 = load ptr, ptr %5, align 8
+  %21 = load ptr, ptr %4, align 8
+  %22 = load ptr, ptr %21, align 8
+  %23 = getelementptr i8, ptr %22, i64 -24
+  %24 = load i64, ptr %23, align 8
+  %25 = getelementptr inbounds i8, ptr %21, i64 %24
+  %26 = invoke i32 @_ZNKSt3__18ios_base5flagsB8ne190102Ev(ptr noundef %25)
+          to label %27 unwind label %72
+
+27:                                               ; preds = %17
+  %28 = and i32 %26, 176
+  %29 = icmp eq i32 %28, 32
+  br i1 %29, label %30, label %34
+
+30:                                               ; preds = %27
+  %31 = load ptr, ptr %5, align 8
+  %32 = load i64, ptr %6, align 8
+  %33 = getelementptr inbounds i8, ptr %31, i64 %32
+  br label %36
+
+34:                                               ; preds = %27
+  %35 = load ptr, ptr %5, align 8
+  br label %36
+
+36:                                               ; preds = %34, %30
+  %37 = phi ptr [ %33, %30 ], [ %35, %34 ]
+  %38 = load ptr, ptr %5, align 8
+  %39 = load i64, ptr %6, align 8
+  %40 = getelementptr inbounds i8, ptr %38, i64 %39
+  %41 = load ptr, ptr %4, align 8
+  %42 = load ptr, ptr %41, align 8
+  %43 = getelementptr i8, ptr %42, i64 -24
+  %44 = load i64, ptr %43, align 8
+  %45 = getelementptr inbounds i8, ptr %41, i64 %44
+  %46 = load ptr, ptr %4, align 8
+  %47 = load ptr, ptr %46, align 8
+  %48 = getelementptr i8, ptr %47, i64 -24
+  %49 = load i64, ptr %48, align 8
+  %50 = getelementptr inbounds i8, ptr %46, i64 %49
+  %51 = invoke signext i8 @_ZNKSt3__19basic_iosIcNS_11char_traitsIcEEE4fillB8ne190102Ev(ptr noundef %50)
+          to label %52 unwind label %72
+
+52:                                               ; preds = %36
+  %53 = getelementptr inbounds %"class.std::__1::ostreambuf_iterator", ptr %11, i32 0, i32 0
+  %54 = load ptr, ptr %53, align 8
+  %55 = ptrtoint ptr %54 to i64
+  %56 = invoke i64 @_ZNSt3__116__pad_and_outputB8ne190102IcNS_11char_traitsIcEEEENS_19ostreambuf_iteratorIT_T0_EES6_PKS4_S8_S8_RNS_8ios_baseES4_(i64 %55, ptr noundef %20, ptr noundef %37, ptr noundef %40, ptr noundef nonnull align 8 dereferenceable(136) %45, i8 noundef signext %51)
+          to label %57 unwind label %72
+
+57:                                               ; preds = %52
+  %58 = getelementptr inbounds %"class.std::__1::ostreambuf_iterator", ptr %10, i32 0, i32 0
+  %59 = inttoptr i64 %56 to ptr
+  store ptr %59, ptr %58, align 8
+  %60 = call zeroext i1 @_ZNKSt3__119ostreambuf_iteratorIcNS_11char_traitsIcEEE6failedB8ne190102Ev(ptr noundef %10) #7
+  br i1 %60, label %61, label %88
+
+61:                                               ; preds = %57
+  %62 = load ptr, ptr %4, align 8
+  %63 = load ptr, ptr %62, align 8
+  %64 = getelementptr i8, ptr %63, i64 -24
+  %65 = load i64, ptr %64, align 8
+  %66 = getelementptr inbounds i8, ptr %62, i64 %65
+  invoke void @_ZNSt3__19basic_iosIcNS_11char_traitsIcEEE8setstateB8ne190102Ej(ptr noundef %66, i32 noundef 5)
+          to label %67 unwind label %72
+
+67:                                               ; preds = %61
+  br label %88
+
+68:                                               ; preds = %3
+  %69 = landingpad { ptr, i32 }
+          catch ptr null
+  %70 = extractvalue { ptr, i32 } %69, 0
+  store ptr %70, ptr %8, align 8
+  %71 = extractvalue { ptr, i32 } %69, 1
+  store i32 %71, ptr %9, align 4
+  br label %77
+
+72:                                               ; preds = %61, %52, %36, %17, %14
+  %73 = landingpad { ptr, i32 }
+          catch ptr null
+  %74 = extractvalue { ptr, i32 } %73, 0
+  store ptr %74, ptr %8, align 8
+  %75 = extractvalue { ptr, i32 } %73, 1
+  store i32 %75, ptr %9, align 4
+  %76 = call ptr @_ZNSt3__113basic_ostreamIcNS_11char_traitsIcEEE6sentryD1Ev(ptr noundef %7) #7
+  br label %77
+
+77:                                               ; preds = %72, %68
+  %78 = load ptr, ptr %8, align 8
+  %79 = call ptr @__cxa_begin_catch(ptr %78) #7
+  %80 = load ptr, ptr %4, align 8
+  %81 = load ptr, ptr %80, align 8
+  %82 = getelementptr i8, ptr %81, i64 -24
+  %83 = load i64, ptr %82, align 8
+  %84 = getelementptr inbounds i8, ptr %80, i64 %83
+  invoke void @_ZNSt3__18ios_base33__set_badbit_and_consider_rethrowEv(ptr noundef %84)
+          to label %85 unwind label %91
+
+85:                                               ; preds = %77
+  call void @__cxa_end_catch()
+  br label %86
+
+86:                                               ; preds = %85, %89
+  %87 = load ptr, ptr %4, align 8
+  ret ptr %87
+
+88:                                               ; preds = %67, %57
+  br label %89
+
+89:                                               ; preds = %88, %16
+  %90 = call ptr @_ZNSt3__113basic_ostreamIcNS_11char_traitsIcEEE6sentryD1Ev(ptr noundef %7) #7
+  br label %86
+
+91:                                               ; preds = %77
+  %92 = landingpad { ptr, i32 }
+          cleanup
+  %93 = extractvalue { ptr, i32 } %92, 0
+  store ptr %93, ptr %8, align 8
+  %94 = extractvalue { ptr, i32 } %92, 1
+  store i32 %94, ptr %9, align 4
+  invoke void @__cxa_end_catch()
+          to label %95 unwind label %101
+
+95:                                               ; preds = %91
+  br label %96
+
+96:                                               ; preds = %95
+  %97 = load ptr, ptr %8, align 8
+  %98 = load i32, ptr %9, align 4
+  %99 = insertvalue { ptr, i32 } poison, ptr %97, 0
+  %100 = insertvalue { ptr, i32 } %99, i32 %98, 1
+  resume { ptr, i32 } %100
+
+101:                                              ; preds = %91
+  %102 = landingpad { ptr, i32 }
+          catch ptr null
+  %103 = extractvalue { ptr, i32 } %102, 0
+  call void @__clang_call_terminate(ptr %103) #8
+  unreachable
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden i64 @_ZNSt3__111char_traitsIcE6lengthB8ne190102EPKc(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = call i64 @_ZNSt3__118__constexpr_strlenB8ne190102IcEEmPKT_(ptr noundef %3) #7
+  ret i64 %4
+}
+
+declare ptr @_ZNSt3__113basic_ostreamIcNS_11char_traitsIcEEE6sentryC1ERS3_(ptr noundef returned, ptr noundef nonnull align 8 dereferenceable(8)) unnamed_addr #3
+
+declare i32 @__gxx_personality_v0(...)
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden zeroext i1 @_ZNKSt3__113basic_ostreamIcNS_11char_traitsIcEEE6sentrycvbB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"class.std::__1::basic_ostream<char>::sentry", ptr %3, i32 0, i32 0
+  %5 = load i8, ptr %4, align 8
+  %6 = trunc i8 %5 to i1
+  ret i1 %6
+}
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr hidden i64 @_ZNSt3__116__pad_and_outputB8ne190102IcNS_11char_traitsIcEEEENS_19ostreambuf_iteratorIT_T0_EES6_PKS4_S8_S8_RNS_8ios_baseES4_(i64 %0, ptr noundef %1, ptr noundef %2, ptr noundef %3, ptr noundef nonnull align 8 dereferenceable(136) %4, i8 noundef signext %5) #0 personality ptr @__gxx_personality_v0 {
+  %7 = alloca %"class.std::__1::ostreambuf_iterator", align 8
+  %8 = alloca %"class.std::__1::ostreambuf_iterator", align 8
+  %9 = alloca ptr, align 8
+  %10 = alloca ptr, align 8
+  %11 = alloca ptr, align 8
+  %12 = alloca ptr, align 8
+  %13 = alloca i8, align 1
+  %14 = alloca i64, align 8
+  %15 = alloca i64, align 8
+  %16 = alloca i64, align 8
+  %17 = alloca %"class.std::__1::basic_string", align 8
+  %18 = alloca ptr, align 8
+  %19 = alloca i32, align 4
+  %20 = alloca i32, align 4
+  %21 = getelementptr inbounds %"class.std::__1::ostreambuf_iterator", ptr %8, i32 0, i32 0
+  %22 = inttoptr i64 %0 to ptr
+  store ptr %22, ptr %21, align 8
+  store ptr %1, ptr %9, align 8
+  store ptr %2, ptr %10, align 8
+  store ptr %3, ptr %11, align 8
+  store ptr %4, ptr %12, align 8
+  store i8 %5, ptr %13, align 1
+  %23 = getelementptr inbounds %"class.std::__1::ostreambuf_iterator", ptr %8, i32 0, i32 0
+  %24 = load ptr, ptr %23, align 8
+  %25 = icmp eq ptr %24, null
+  br i1 %25, label %26, label %27
+
+26:                                               ; preds = %6
+  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %7, ptr align 8 %8, i64 8, i1 false)
+  br label %111
+
+27:                                               ; preds = %6
+  %28 = load ptr, ptr %11, align 8
+  %29 = load ptr, ptr %9, align 8
+  %30 = ptrtoint ptr %28 to i64
+  %31 = ptrtoint ptr %29 to i64
+  %32 = sub i64 %30, %31
+  store i64 %32, ptr %14, align 8
+  %33 = load ptr, ptr %12, align 8
+  %34 = call i64 @_ZNKSt3__18ios_base5widthB8ne190102Ev(ptr noundef %33)
+  store i64 %34, ptr %15, align 8
+  %35 = load i64, ptr %15, align 8
+  %36 = load i64, ptr %14, align 8
+  %37 = icmp sgt i64 %35, %36
+  br i1 %37, label %38, label %42
+
+38:                                               ; preds = %27
+  %39 = load i64, ptr %14, align 8
+  %40 = load i64, ptr %15, align 8
+  %41 = sub nsw i64 %40, %39
+  store i64 %41, ptr %15, align 8
+  br label %43
+
+42:                                               ; preds = %27
+  store i64 0, ptr %15, align 8
+  br label %43
+
+43:                                               ; preds = %42, %38
+  %44 = load ptr, ptr %10, align 8
+  %45 = load ptr, ptr %9, align 8
+  %46 = ptrtoint ptr %44 to i64
+  %47 = ptrtoint ptr %45 to i64
+  %48 = sub i64 %46, %47
+  store i64 %48, ptr %16, align 8
+  %49 = load i64, ptr %16, align 8
+  %50 = icmp sgt i64 %49, 0
+  br i1 %50, label %51, label %62
+
+51:                                               ; preds = %43
+  %52 = getelementptr inbounds %"class.std::__1::ostreambuf_iterator", ptr %8, i32 0, i32 0
+  %53 = load ptr, ptr %52, align 8
+  %54 = load ptr, ptr %9, align 8
+  %55 = load i64, ptr %16, align 8
+  %56 = call i64 @_ZNSt3__115basic_streambufIcNS_11char_traitsIcEEE5sputnB8ne190102EPKcl(ptr noundef %53, ptr noundef %54, i64 noundef %55)
+  %57 = load i64, ptr %16, align 8
+  %58 = icmp ne i64 %56, %57
+  br i1 %58, label %59, label %61
+
+59:                                               ; preds = %51
+  %60 = getelementptr inbounds %"class.std::__1::ostreambuf_iterator", ptr %8, i32 0, i32 0
+  store ptr null, ptr %60, align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %7, ptr align 8 %8, i64 8, i1 false)
+  br label %111
+
+61:                                               ; preds = %51
+  br label %62
+
+62:                                               ; preds = %61, %43
+  %63 = load i64, ptr %15, align 8
+  %64 = icmp sgt i64 %63, 0
+  br i1 %64, label %65, label %89
+
+65:                                               ; preds = %62
+  %66 = load i64, ptr %15, align 8
+  %67 = load i8, ptr %13, align 1
+  %68 = call ptr @_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEC1B8ne190102Emc(ptr noundef %17, i64 noundef %66, i8 noundef signext %67)
+  %69 = getelementptr inbounds %"class.std::__1::ostreambuf_iterator", ptr %8, i32 0, i32 0
+  %70 = load ptr, ptr %69, align 8
+  %71 = call ptr @_ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE4dataB8ne190102Ev(ptr noundef %17) #7
+  %72 = load i64, ptr %15, align 8
+  %73 = invoke i64 @_ZNSt3__115basic_streambufIcNS_11char_traitsIcEEE5sputnB8ne190102EPKcl(ptr noundef %70, ptr noundef %71, i64 noundef %72)
+          to label %74 unwind label %79
+
+74:                                               ; preds = %65
+  %75 = load i64, ptr %15, align 8
+  %76 = icmp ne i64 %73, %75
+  br i1 %76, label %77, label %84
+
+77:                                               ; preds = %74
+  %78 = getelementptr inbounds %"class.std::__1::ostreambuf_iterator", ptr %8, i32 0, i32 0
+  store ptr null, ptr %78, align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %7, ptr align 8 %8, i64 8, i1 false)
+  store i32 1, ptr %20, align 4
+  br label %85
+
+79:                                               ; preds = %65
+  %80 = landingpad { ptr, i32 }
+          cleanup
+  %81 = extractvalue { ptr, i32 } %80, 0
+  store ptr %81, ptr %18, align 8
+  %82 = extractvalue { ptr, i32 } %80, 1
+  store i32 %82, ptr %19, align 4
+  %83 = call ptr @_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEED1Ev(ptr noundef %17) #7
+  br label %115
+
+84:                                               ; preds = %74
+  store i32 0, ptr %20, align 4
+  br label %85
+
+85:                                               ; preds = %84, %77
+  %86 = call ptr @_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEED1Ev(ptr noundef %17) #7
+  %87 = load i32, ptr %20, align 4
+  switch i32 %87, label %120 [
+    i32 0, label %88
+    i32 1, label %111
+  ]
+
+88:                                               ; preds = %85
+  br label %89
+
+89:                                               ; preds = %88, %62
+  %90 = load ptr, ptr %11, align 8
+  %91 = load ptr, ptr %10, align 8
+  %92 = ptrtoint ptr %90 to i64
+  %93 = ptrtoint ptr %91 to i64
+  %94 = sub i64 %92, %93
+  store i64 %94, ptr %16, align 8
+  %95 = load i64, ptr %16, align 8
+  %96 = icmp sgt i64 %95, 0
+  br i1 %96, label %97, label %108
+
+97:                                               ; preds = %89
+  %98 = getelementptr inbounds %"class.std::__1::ostreambuf_iterator", ptr %8, i32 0, i32 0
+  %99 = load ptr, ptr %98, align 8
+  %100 = load ptr, ptr %10, align 8
+  %101 = load i64, ptr %16, align 8
+  %102 = call i64 @_ZNSt3__115basic_streambufIcNS_11char_traitsIcEEE5sputnB8ne190102EPKcl(ptr noundef %99, ptr noundef %100, i64 noundef %101)
+  %103 = load i64, ptr %16, align 8
+  %104 = icmp ne i64 %102, %103
+  br i1 %104, label %105, label %107
+
+105:                                              ; preds = %97
+  %106 = getelementptr inbounds %"class.std::__1::ostreambuf_iterator", ptr %8, i32 0, i32 0
+  store ptr null, ptr %106, align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %7, ptr align 8 %8, i64 8, i1 false)
+  br label %111
+
+107:                                              ; preds = %97
+  br label %108
+
+108:                                              ; preds = %107, %89
+  %109 = load ptr, ptr %12, align 8
+  %110 = call i64 @_ZNSt3__18ios_base5widthB8ne190102El(ptr noundef %109, i64 noundef 0)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %7, ptr align 8 %8, i64 8, i1 false)
+  br label %111
+
+111:                                              ; preds = %108, %105, %85, %59, %26
+  %112 = getelementptr inbounds %"class.std::__1::ostreambuf_iterator", ptr %7, i32 0, i32 0
+  %113 = load ptr, ptr %112, align 8
+  %114 = ptrtoint ptr %113 to i64
+  ret i64 %114
+
+115:                                              ; preds = %79
+  %116 = load ptr, ptr %18, align 8
+  %117 = load i32, ptr %19, align 4
+  %118 = insertvalue { ptr, i32 } poison, ptr %116, 0
+  %119 = insertvalue { ptr, i32 } %118, i32 %117, 1
+  resume { ptr, i32 } %119
+
+120:                                              ; preds = %85
+  unreachable
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNSt3__119ostreambuf_iteratorIcNS_11char_traitsIcEEEC1B8ne190102ERNS_13basic_ostreamIcS2_EE(ptr noundef returned %0, ptr noundef nonnull align 8 dereferenceable(8) %1) unnamed_addr #2 {
+  %3 = alloca ptr, align 8
+  %4 = alloca ptr, align 8
+  store ptr %0, ptr %3, align 8
+  store ptr %1, ptr %4, align 8
+  %5 = load ptr, ptr %3, align 8
+  %6 = load ptr, ptr %4, align 8
+  %7 = call ptr @_ZNSt3__119ostreambuf_iteratorIcNS_11char_traitsIcEEEC2B8ne190102ERNS_13basic_ostreamIcS2_EE(ptr noundef %5, ptr noundef nonnull align 8 dereferenceable(8) %6) #7
+  ret ptr %5
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden i32 @_ZNKSt3__18ios_base5flagsB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"class.std::__1::ios_base", ptr %3, i32 0, i32 1
+  %5 = load i32, ptr %4, align 8
+  ret i32 %5
+}
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr hidden signext i8 @_ZNKSt3__19basic_iosIcNS_11char_traitsIcEEE4fillB8ne190102Ev(ptr noundef %0) #0 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"class.std::__1::basic_ios", ptr %3, i32 0, i32 2
+  %5 = call zeroext i1 @_ZNKSt3__118_SentinelValueFillINS_11char_traitsIcEEE8__is_setB8ne190102Ev(ptr noundef %4)
+  br i1 %5, label %11, label %6
+
+6:                                                ; preds = %1
+  %7 = call signext i8 @_ZNKSt3__19basic_iosIcNS_11char_traitsIcEEE5widenB8ne190102Ec(ptr noundef %3, i8 noundef signext 32)
+  %8 = sext i8 %7 to i32
+  %9 = getelementptr inbounds %"class.std::__1::basic_ios", ptr %3, i32 0, i32 2
+  %10 = call noundef nonnull align 1 dereferenceable(4) ptr @_ZNSt3__118_SentinelValueFillINS_11char_traitsIcEEEaSB8ne190102Ei(ptr noundef %9, i32 noundef %8)
+  br label %11
+
+11:                                               ; preds = %6, %1
+  %12 = getelementptr inbounds %"class.std::__1::basic_ios", ptr %3, i32 0, i32 2
+  %13 = call i32 @_ZNKSt3__118_SentinelValueFillINS_11char_traitsIcEEE5__getB8ne190102Ev(ptr noundef %12)
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden zeroext i1 @_ZNKSt3__119ostreambuf_iteratorIcNS_11char_traitsIcEEE6failedB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"class.std::__1::ostreambuf_iterator", ptr %3, i32 0, i32 0
+  %5 = load ptr, ptr %4, align 8
+  %6 = icmp eq ptr %5, null
+  ret i1 %6
+}
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr hidden void @_ZNSt3__19basic_iosIcNS_11char_traitsIcEEE8setstateB8ne190102Ej(ptr noundef %0, i32 noundef %1) #0 {
+  %3 = alloca ptr, align 8
+  %4 = alloca i32, align 4
+  store ptr %0, ptr %3, align 8
+  store i32 %1, ptr %4, align 4
+  %5 = load ptr, ptr %3, align 8
+  %6 = load i32, ptr %4, align 4
+  call void @_ZNSt3__18ios_base8setstateB8ne190102Ej(ptr noundef %5, i32 noundef %6)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare ptr @_ZNSt3__113basic_ostreamIcNS_11char_traitsIcEEE6sentryD1Ev(ptr noundef returned) unnamed_addr #4
+
+declare ptr @__cxa_begin_catch(ptr)
+
+declare void @_ZNSt3__18ios_base33__set_badbit_and_consider_rethrowEv(ptr noundef) #3
+
+declare void @__cxa_end_catch()
+
+; Function Attrs: noinline noreturn nounwind ssp uwtable(sync)
+define linkonce_odr hidden void @__clang_call_terminate(ptr noundef %0) #5 {
+  %2 = call ptr @__cxa_begin_catch(ptr %0) #7
+  call void @_ZSt9terminatev() #8
+  unreachable
+}
+
+declare void @_ZSt9terminatev()
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #6
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden i64 @_ZNKSt3__18ios_base5widthB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"class.std::__1::ios_base", ptr %3, i32 0, i32 3
+  %5 = load i64, ptr %4, align 8
+  ret i64 %5
+}
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr hidden i64 @_ZNSt3__115basic_streambufIcNS_11char_traitsIcEEE5sputnB8ne190102EPKcl(ptr noundef %0, ptr noundef %1, i64 noundef %2) #0 {
+  %4 = alloca ptr, align 8
+  %5 = alloca ptr, align 8
+  %6 = alloca i64, align 8
+  store ptr %0, ptr %4, align 8
+  store ptr %1, ptr %5, align 8
+  store i64 %2, ptr %6, align 8
+  %7 = load ptr, ptr %4, align 8
+  %8 = load ptr, ptr %5, align 8
+  %9 = load i64, ptr %6, align 8
+  %10 = load ptr, ptr %7, align 8
+  %11 = getelementptr inbounds ptr, ptr %10, i64 12
+  %12 = load ptr, ptr %11, align 8
+  %13 = call i64 %12(ptr noundef %7, ptr noundef %8, i64 noundef %9)
+  ret i64 %13
+}
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEC1B8ne190102Emc(ptr noundef returned %0, i64 noundef %1, i8 noundef signext %2) unnamed_addr #0 {
+  %4 = alloca ptr, align 8
+  %5 = alloca i64, align 8
+  %6 = alloca i8, align 1
+  store ptr %0, ptr %4, align 8
+  store i64 %1, ptr %5, align 8
+  store i8 %2, ptr %6, align 1
+  %7 = load ptr, ptr %4, align 8
+  %8 = load i64, ptr %5, align 8
+  %9 = load i8, ptr %6, align 1
+  %10 = call ptr @_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEC2B8ne190102Emc(ptr noundef %7, i64 noundef %8, i8 noundef signext %9)
+  ret ptr %7
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE4dataB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = call ptr @_ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE13__get_pointerB8ne190102Ev(ptr noundef %3) #7
+  %5 = call ptr @_ZNSt3__112__to_addressB8ne190102IKcEEPT_S3_(ptr noundef %4) #7
+  ret ptr %5
+}
+
+; Function Attrs: nounwind
+declare ptr @_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEED1Ev(ptr noundef returned) unnamed_addr #4
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden i64 @_ZNSt3__18ios_base5widthB8ne190102El(ptr noundef %0, i64 noundef %1) #2 {
+  %3 = alloca ptr, align 8
+  %4 = alloca i64, align 8
+  %5 = alloca i64, align 8
+  store ptr %0, ptr %3, align 8
+  store i64 %1, ptr %4, align 8
+  %6 = load ptr, ptr %3, align 8
+  %7 = getelementptr inbounds %"class.std::__1::ios_base", ptr %6, i32 0, i32 3
+  %8 = load i64, ptr %7, align 8
+  store i64 %8, ptr %5, align 8
+  %9 = load i64, ptr %4, align 8
+  %10 = getelementptr inbounds %"class.std::__1::ios_base", ptr %6, i32 0, i32 3
+  store i64 %9, ptr %10, align 8
+  %11 = load i64, ptr %5, align 8
+  ret i64 %11
+}
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEC2B8ne190102Emc(ptr noundef returned %0, i64 noundef %1, i8 noundef signext %2) unnamed_addr #0 {
+  %4 = alloca ptr, align 8
+  %5 = alloca i64, align 8
+  %6 = alloca i8, align 1
+  %7 = alloca %"struct.std::__1::__default_init_tag", align 1
+  %8 = alloca %"struct.std::__1::__default_init_tag", align 1
+  store ptr %0, ptr %4, align 8
+  store i64 %1, ptr %5, align 8
+  store i8 %2, ptr %6, align 1
+  %9 = load ptr, ptr %4, align 8
+  %10 = getelementptr inbounds %"class.std::__1::basic_string", ptr %9, i32 0, i32 0
+  %11 = call ptr @_ZNSt3__117__compressed_pairINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE5__repES5_EC1B8ne190102INS_18__default_init_tagESA_EEOT_OT0_(ptr noundef %10, ptr noundef nonnull align 1 dereferenceable(1) %7, ptr noundef nonnull align 1 dereferenceable(1) %8)
+  %12 = load i64, ptr %5, align 8
+  %13 = load i8, ptr %6, align 1
+  call void @_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6__initEmc(ptr noundef %9, i64 noundef %12, i8 noundef signext %13)
+  ret ptr %9
+}
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr ptr @_ZNSt3__117__compressed_pairINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE5__repES5_EC1B8ne190102INS_18__default_init_tagESA_EEOT_OT0_(ptr noundef returned %0, ptr noundef nonnull align 1 dereferenceable(1) %1, ptr noundef nonnull align 1 dereferenceable(1) %2) unnamed_addr #0 {
+  %4 = alloca ptr, align 8
+  %5 = alloca ptr, align 8
+  %6 = alloca ptr, align 8
+  store ptr %0, ptr %4, align 8
+  store ptr %1, ptr %5, align 8
+  store ptr %2, ptr %6, align 8
+  %7 = load ptr, ptr %4, align 8
+  %8 = load ptr, ptr %5, align 8
+  %9 = load ptr, ptr %6, align 8
+  %10 = call ptr @_ZNSt3__117__compressed_pairINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE5__repES5_EC2B8ne190102INS_18__default_init_tagESA_EEOT_OT0_(ptr noundef %7, ptr noundef nonnull align 1 dereferenceable(1) %8, ptr noundef nonnull align 1 dereferenceable(1) %9)
+  ret ptr %7
+}
+
+declare void @_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6__initEmc(ptr noundef, i64 noundef, i8 noundef signext) #3
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr ptr @_ZNSt3__117__compressed_pairINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE5__repES5_EC2B8ne190102INS_18__default_init_tagESA_EEOT_OT0_(ptr noundef returned %0, ptr noundef nonnull align 1 dereferenceable(1) %1, ptr noundef nonnull align 1 dereferenceable(1) %2) unnamed_addr #0 {
+  %4 = alloca ptr, align 8
+  %5 = alloca ptr, align 8
+  %6 = alloca ptr, align 8
+  %7 = alloca %"struct.std::__1::__default_init_tag", align 1
+  %8 = alloca %"struct.std::__1::__default_init_tag", align 1
+  store ptr %0, ptr %4, align 8
+  store ptr %1, ptr %5, align 8
+  store ptr %2, ptr %6, align 8
+  %9 = load ptr, ptr %4, align 8
+  %10 = load ptr, ptr %5, align 8
+  %11 = call ptr @_ZNSt3__122__compressed_pair_elemINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE5__repELi0ELb0EEC2B8ne190102ENS_18__default_init_tagE(ptr noundef %9)
+  %12 = load ptr, ptr %6, align 8
+  %13 = call ptr @_ZNSt3__122__compressed_pair_elemINS_9allocatorIcEELi1ELb1EEC2B8ne190102ENS_18__default_init_tagE(ptr noundef %9)
+  ret ptr %9
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNSt3__122__compressed_pair_elemINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE5__repELi0ELb0EEC2B8ne190102ENS_18__default_init_tagE(ptr noundef returned %0) unnamed_addr #2 {
+  %2 = alloca %"struct.std::__1::__default_init_tag", align 1
+  %3 = alloca ptr, align 8
+  store ptr %0, ptr %3, align 8
+  %4 = load ptr, ptr %3, align 8
+  %5 = getelementptr inbounds %"struct.std::__1::__compressed_pair_elem", ptr %4, i32 0, i32 0
+  ret ptr %4
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNSt3__122__compressed_pair_elemINS_9allocatorIcEELi1ELb1EEC2B8ne190102ENS_18__default_init_tagE(ptr noundef returned %0) unnamed_addr #2 {
+  %2 = alloca %"struct.std::__1::__default_init_tag", align 1
+  %3 = alloca ptr, align 8
+  store ptr %0, ptr %3, align 8
+  %4 = load ptr, ptr %3, align 8
+  %5 = call ptr @_ZNSt3__19allocatorIcEC2B8ne190102Ev(ptr noundef %4) #7
+  ret ptr %4
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNSt3__19allocatorIcEC2B8ne190102Ev(ptr noundef returned %0) unnamed_addr #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = call ptr @_ZNSt3__116__non_trivial_ifILb1ENS_9allocatorIcEEEC2B8ne190102Ev(ptr noundef %3) #7
+  ret ptr %3
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNSt3__116__non_trivial_ifILb1ENS_9allocatorIcEEEC2B8ne190102Ev(ptr noundef returned %0) unnamed_addr #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  ret ptr %3
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNSt3__112__to_addressB8ne190102IKcEEPT_S3_(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  ret ptr %3
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE13__get_pointerB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = call zeroext i1 @_ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE9__is_longB8ne190102Ev(ptr noundef %3) #7
+  br i1 %4, label %5, label %7
+
+5:                                                ; preds = %1
+  %6 = call ptr @_ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE18__get_long_pointerB8ne190102Ev(ptr noundef %3) #7
+  br label %9
+
+7:                                                ; preds = %1
+  %8 = call ptr @_ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE19__get_short_pointerB8ne190102Ev(ptr noundef %3) #7
+  br label %9
+
+9:                                                ; preds = %7, %5
+  %10 = phi ptr [ %6, %5 ], [ %8, %7 ]
+  ret ptr %10
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden zeroext i1 @_ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE9__is_longB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"class.std::__1::basic_string", ptr %3, i32 0, i32 0
+  %5 = call noundef nonnull align 8 dereferenceable(24) ptr @_ZNKSt3__117__compressed_pairINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE5__repES5_E5firstB8ne190102Ev(ptr noundef %4) #7
+  %6 = getelementptr inbounds %"struct.std::__1::basic_string<char>::__short", ptr %5, i32 0, i32 2
+  %7 = load i8, ptr %6, align 1
+  %8 = lshr i8 %7, 7
+  %9 = icmp ne i8 %8, 0
+  ret i1 %9
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE18__get_long_pointerB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"class.std::__1::basic_string", ptr %3, i32 0, i32 0
+  %5 = call noundef nonnull align 8 dereferenceable(24) ptr @_ZNKSt3__117__compressed_pairINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE5__repES5_E5firstB8ne190102Ev(ptr noundef %4) #7
+  %6 = getelementptr inbounds %"struct.std::__1::basic_string<char>::__long", ptr %5, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
+  ret ptr %7
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE19__get_short_pointerB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"class.std::__1::basic_string", ptr %3, i32 0, i32 0
+  %5 = call noundef nonnull align 8 dereferenceable(24) ptr @_ZNKSt3__117__compressed_pairINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE5__repES5_E5firstB8ne190102Ev(ptr noundef %4) #7
+  %6 = getelementptr inbounds %"struct.std::__1::basic_string<char>::__short", ptr %5, i32 0, i32 0
+  %7 = getelementptr inbounds [23 x i8], ptr %6, i64 0, i64 0
+  %8 = call ptr @_ZNSt3__114pointer_traitsIPKcE10pointer_toB8ne190102ERS1_(ptr noundef nonnull align 1 dereferenceable(1) %7) #7
+  ret ptr %8
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden noundef nonnull align 8 dereferenceable(24) ptr @_ZNKSt3__117__compressed_pairINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE5__repES5_E5firstB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = call noundef nonnull align 8 dereferenceable(24) ptr @_ZNKSt3__122__compressed_pair_elemINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE5__repELi0ELb0EE5__getB8ne190102Ev(ptr noundef %3) #7
+  ret ptr %4
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden noundef nonnull align 8 dereferenceable(24) ptr @_ZNKSt3__122__compressed_pair_elemINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE5__repELi0ELb0EE5__getB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"struct.std::__1::__compressed_pair_elem", ptr %3, i32 0, i32 0
+  ret ptr %4
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNSt3__114pointer_traitsIPKcE10pointer_toB8ne190102ERS1_(ptr noundef nonnull align 1 dereferenceable(1) %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  ret ptr %3
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNSt3__119ostreambuf_iteratorIcNS_11char_traitsIcEEEC2B8ne190102ERNS_13basic_ostreamIcS2_EE(ptr noundef returned %0, ptr noundef nonnull align 8 dereferenceable(8) %1) unnamed_addr #2 personality ptr @__gxx_personality_v0 {
+  %3 = alloca ptr, align 8
+  %4 = alloca ptr, align 8
+  store ptr %0, ptr %3, align 8
+  store ptr %1, ptr %4, align 8
+  %5 = load ptr, ptr %3, align 8
+  %6 = getelementptr inbounds %"class.std::__1::ostreambuf_iterator", ptr %5, i32 0, i32 0
+  %7 = load ptr, ptr %4, align 8
+  %8 = load ptr, ptr %7, align 8
+  %9 = getelementptr i8, ptr %8, i64 -24
+  %10 = load i64, ptr %9, align 8
+  %11 = getelementptr inbounds i8, ptr %7, i64 %10
+  %12 = invoke ptr @_ZNKSt3__19basic_iosIcNS_11char_traitsIcEEE5rdbufB8ne190102Ev(ptr noundef %11)
+          to label %13 unwind label %14
+
+13:                                               ; preds = %2
+  store ptr %12, ptr %6, align 8
+  ret ptr %5
+
+14:                                               ; preds = %2
+  %15 = landingpad { ptr, i32 }
+          catch ptr null
+  %16 = extractvalue { ptr, i32 } %15, 0
+  call void @__clang_call_terminate(ptr %16) #8
+  unreachable
+}
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNKSt3__19basic_iosIcNS_11char_traitsIcEEE5rdbufB8ne190102Ev(ptr noundef %0) #0 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = call ptr @_ZNKSt3__18ios_base5rdbufB8ne190102Ev(ptr noundef %3)
+  ret ptr %4
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden ptr @_ZNKSt3__18ios_base5rdbufB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"class.std::__1::ios_base", ptr %3, i32 0, i32 6
+  %5 = load ptr, ptr %4, align 8
+  ret ptr %5
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden zeroext i1 @_ZNKSt3__118_SentinelValueFillINS_11char_traitsIcEEE8__is_setB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"struct.std::__1::_SentinelValueFill", ptr %3, i32 0, i32 0
+  %5 = load i32, ptr %4, align 1
+  %6 = call i32 @_ZNSt3__111char_traitsIcE3eofB8ne190102Ev() #7
+  %7 = icmp ne i32 %5, %6
+  ret i1 %7
+}
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr hidden signext i8 @_ZNKSt3__19basic_iosIcNS_11char_traitsIcEEE5widenB8ne190102Ec(ptr noundef %0, i8 noundef signext %1) #0 personality ptr @__gxx_personality_v0 {
+  %3 = alloca ptr, align 8
+  %4 = alloca i8, align 1
+  %5 = alloca %"class.std::__1::locale", align 8
+  %6 = alloca ptr, align 8
+  %7 = alloca i32, align 4
+  store ptr %0, ptr %3, align 8
+  store i8 %1, ptr %4, align 1
+  %8 = load ptr, ptr %3, align 8
+  call void @_ZNKSt3__18ios_base6getlocEv(ptr dead_on_unwind writable sret(%"class.std::__1::locale") align 8 %5, ptr noundef %8)
+  %9 = invoke noundef nonnull align 8 dereferenceable(25) ptr @_ZNSt3__19use_facetB8ne190102INS_5ctypeIcEEEERKT_RKNS_6localeE(ptr noundef nonnull align 8 dereferenceable(8) %5)
+          to label %10 unwind label %15
+
+10:                                               ; preds = %2
+  %11 = load i8, ptr %4, align 1
+  %12 = invoke signext i8 @_ZNKSt3__15ctypeIcE5widenB8ne190102Ec(ptr noundef %9, i8 noundef signext %11)
+          to label %13 unwind label %15
+
+13:                                               ; preds = %10
+  %14 = call ptr @_ZNSt3__16localeD1Ev(ptr noundef %5) #7
+  ret i8 %12
+
+15:                                               ; preds = %10, %2
+  %16 = landingpad { ptr, i32 }
+          cleanup
+  %17 = extractvalue { ptr, i32 } %16, 0
+  store ptr %17, ptr %6, align 8
+  %18 = extractvalue { ptr, i32 } %16, 1
+  store i32 %18, ptr %7, align 4
+  %19 = call ptr @_ZNSt3__16localeD1Ev(ptr noundef %5) #7
+  br label %20
+
+20:                                               ; preds = %15
+  %21 = load ptr, ptr %6, align 8
+  %22 = load i32, ptr %7, align 4
+  %23 = insertvalue { ptr, i32 } poison, ptr %21, 0
+  %24 = insertvalue { ptr, i32 } %23, i32 %22, 1
+  resume { ptr, i32 } %24
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden noundef nonnull align 1 dereferenceable(4) ptr @_ZNSt3__118_SentinelValueFillINS_11char_traitsIcEEEaSB8ne190102Ei(ptr noundef %0, i32 noundef %1) #2 {
+  %3 = alloca ptr, align 8
+  %4 = alloca i32, align 4
+  store ptr %0, ptr %3, align 8
+  store i32 %1, ptr %4, align 4
+  %5 = load ptr, ptr %3, align 8
+  %6 = load i32, ptr %4, align 4
+  %7 = getelementptr inbounds %"struct.std::__1::_SentinelValueFill", ptr %5, i32 0, i32 0
+  store i32 %6, ptr %7, align 1
+  ret ptr %5
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden i32 @_ZNKSt3__118_SentinelValueFillINS_11char_traitsIcEEE5__getB8ne190102Ev(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"struct.std::__1::_SentinelValueFill", ptr %3, i32 0, i32 0
+  %5 = load i32, ptr %4, align 1
+  ret i32 %5
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden i32 @_ZNSt3__111char_traitsIcE3eofB8ne190102Ev() #2 {
+  ret i32 -1
+}
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr hidden noundef nonnull align 8 dereferenceable(25) ptr @_ZNSt3__19use_facetB8ne190102INS_5ctypeIcEEEERKT_RKNS_6localeE(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = call ptr @_ZNKSt3__16locale9use_facetERNS0_2idE(ptr noundef %3, ptr noundef nonnull align 8 dereferenceable(12) @_ZNSt3__15ctypeIcE2idE)
+  ret ptr %4
+}
+
+declare void @_ZNKSt3__18ios_base6getlocEv(ptr dead_on_unwind writable sret(%"class.std::__1::locale") align 8, ptr noundef) #3
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr hidden signext i8 @_ZNKSt3__15ctypeIcE5widenB8ne190102Ec(ptr noundef %0, i8 noundef signext %1) #0 {
+  %3 = alloca ptr, align 8
+  %4 = alloca i8, align 1
+  store ptr %0, ptr %3, align 8
+  store i8 %1, ptr %4, align 1
+  %5 = load ptr, ptr %3, align 8
+  %6 = load i8, ptr %4, align 1
+  %7 = load ptr, ptr %5, align 8
+  %8 = getelementptr inbounds ptr, ptr %7, i64 7
+  %9 = load ptr, ptr %8, align 8
+  %10 = call signext i8 %9(ptr noundef %5, i8 noundef signext %6)
+  ret i8 %10
+}
+
+; Function Attrs: nounwind
+declare ptr @_ZNSt3__16localeD1Ev(ptr noundef returned) unnamed_addr #4
+
+declare ptr @_ZNKSt3__16locale9use_facetERNS0_2idE(ptr noundef, ptr noundef nonnull align 8 dereferenceable(12)) #3
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable(sync)
+define linkonce_odr hidden void @_ZNSt3__18ios_base8setstateB8ne190102Ej(ptr noundef %0, i32 noundef %1) #0 {
+  %3 = alloca ptr, align 8
+  %4 = alloca i32, align 4
+  store ptr %0, ptr %3, align 8
+  store i32 %1, ptr %4, align 4
+  %5 = load ptr, ptr %3, align 8
+  %6 = getelementptr inbounds %"class.std::__1::ios_base", ptr %5, i32 0, i32 4
+  %7 = load i32, ptr %6, align 8
+  %8 = load i32, ptr %4, align 4
+  %9 = or i32 %7, %8
+  call void @_ZNSt3__18ios_base5clearEj(ptr noundef %5, i32 noundef %9)
+  ret void
+}
+
+declare void @_ZNSt3__18ios_base5clearEj(ptr noundef, i32 noundef) #3
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define linkonce_odr hidden i64 @_ZNSt3__118__constexpr_strlenB8ne190102IcEEmPKT_(ptr noundef %0) #2 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = call i64 @strlen(ptr noundef %3) #7
+  ret i64 %4
+}
+
+; Function Attrs: nounwind
+declare i64 @strlen(ptr noundef) #4
+
+attributes #0 = { mustprogress noinline optnone ssp uwtable(sync) "frame-pointer"="non-leaf" "no-trapping-math"="true" "probe-stack"="__chkstk_darwin" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+altnzcv,+bti,+ccdp,+ccidx,+complxnum,+crc,+dit,+dotprod,+flagm,+fp-armv8,+fp16fml,+fptoint,+fullfp16,+jsconv,+lse,+neon,+pauth,+perfmon,+predres,+ras,+rcpc,+rdm,+sb,+sha2,+sha3,+specrestrict,+ssbs,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+attributes #1 = { mustprogress noinline norecurse optnone ssp uwtable(sync) "frame-pointer"="non-leaf" "no-trapping-math"="true" "probe-stack"="__chkstk_darwin" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+altnzcv,+bti,+ccdp,+ccidx,+complxnum,+crc,+dit,+dotprod,+flagm,+fp-armv8,+fp16fml,+fptoint,+fullfp16,+jsconv,+lse,+neon,+pauth,+perfmon,+predres,+ras,+rcpc,+rdm,+sb,+sha2,+sha3,+specrestrict,+ssbs,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+attributes #2 = { mustprogress noinline nounwind optnone ssp uwtable(sync) "frame-pointer"="non-leaf" "no-trapping-math"="true" "probe-stack"="__chkstk_darwin" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+altnzcv,+bti,+ccdp,+ccidx,+complxnum,+crc,+dit,+dotprod,+flagm,+fp-armv8,+fp16fml,+fptoint,+fullfp16,+jsconv,+lse,+neon,+pauth,+perfmon,+predres,+ras,+rcpc,+rdm,+sb,+sha2,+sha3,+specrestrict,+ssbs,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+attributes #3 = { "frame-pointer"="non-leaf" "no-trapping-math"="true" "probe-stack"="__chkstk_darwin" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+altnzcv,+bti,+ccdp,+ccidx,+complxnum,+crc,+dit,+dotprod,+flagm,+fp-armv8,+fp16fml,+fptoint,+fullfp16,+jsconv,+lse,+neon,+pauth,+perfmon,+predres,+ras,+rcpc,+rdm,+sb,+sha2,+sha3,+specrestrict,+ssbs,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+attributes #4 = { nounwind "frame-pointer"="non-leaf" "no-trapping-math"="true" "probe-stack"="__chkstk_darwin" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+altnzcv,+bti,+ccdp,+ccidx,+complxnum,+crc,+dit,+dotprod,+flagm,+fp-armv8,+fp16fml,+fptoint,+fullfp16,+jsconv,+lse,+neon,+pauth,+perfmon,+predres,+ras,+rcpc,+rdm,+sb,+sha2,+sha3,+specrestrict,+ssbs,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+attributes #5 = { noinline noreturn nounwind ssp uwtable(sync) "frame-pointer"="non-leaf" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+altnzcv,+bti,+ccdp,+ccidx,+complxnum,+crc,+dit,+dotprod,+flagm,+fp-armv8,+fp16fml,+fptoint,+fullfp16,+jsconv,+lse,+neon,+pauth,+perfmon,+predres,+ras,+rcpc,+rdm,+sb,+sha2,+sha3,+specrestrict,+ssbs,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+attributes #6 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #7 = { nounwind }
+attributes #8 = { noreturn nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 2, !"SDK Version", [2 x i32] [i32 15, i32 5]}
+!1 = !{i32 1, !"wchar_size", i32 4}
+!2 = !{i32 8, !"PIC Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 1}
+!4 = !{i32 7, !"frame-pointer", i32 1}
+!5 = !{!"Apple clang version 17.0.0 (clang-1700.0.13.5)"}

--- a/test-files/test1.cpp
+++ b/test-files/test1.cpp
@@ -1,0 +1,9 @@
+int add(int a, int b) { return a + b; }
+
+int subtract(int a, int b) { return a - b; }
+
+int main() {
+  int x = add(4, 5);
+  int y = subtract(9, 3);
+  return 0;
+}

--- a/test-files/test1.ll
+++ b/test-files/test1.ll
@@ -1,0 +1,54 @@
+; ModuleID = 'test1.cpp'
+source_filename = "test1.cpp"
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "arm64-apple-macosx15.0.0"
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  store i32 %0, ptr %3, align 4
+  store i32 %1, ptr %4, align 4
+  %5 = load i32, ptr %3, align 4
+  %6 = load i32, ptr %4, align 4
+  %7 = add nsw i32 %5, %6
+  ret i32 %7
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define i32 @_Z8subtractii(i32 noundef %0, i32 noundef %1) #0 {
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  store i32 %0, ptr %3, align 4
+  store i32 %1, ptr %4, align 4
+  %5 = load i32, ptr %3, align 4
+  %6 = load i32, ptr %4, align 4
+  %7 = sub nsw i32 %5, %6
+  ret i32 %7
+}
+
+; Function Attrs: mustprogress noinline norecurse nounwind optnone ssp uwtable(sync)
+define i32 @main() #1 {
+  %1 = alloca i32, align 4
+  %2 = alloca i32, align 4
+  %3 = alloca i32, align 4
+  store i32 0, ptr %1, align 4
+  %4 = call i32 @_Z3addii(i32 noundef 4, i32 noundef 5)
+  store i32 %4, ptr %2, align 4
+  %5 = call i32 @_Z8subtractii(i32 noundef 9, i32 noundef 3)
+  store i32 %5, ptr %3, align 4
+  ret i32 0
+}
+
+attributes #0 = { mustprogress noinline nounwind optnone ssp uwtable(sync) "frame-pointer"="non-leaf" "no-trapping-math"="true" "probe-stack"="__chkstk_darwin" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+altnzcv,+bti,+ccdp,+ccidx,+complxnum,+crc,+dit,+dotprod,+flagm,+fp-armv8,+fp16fml,+fptoint,+fullfp16,+jsconv,+lse,+neon,+pauth,+perfmon,+predres,+ras,+rcpc,+rdm,+sb,+sha2,+sha3,+specrestrict,+ssbs,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+attributes #1 = { mustprogress noinline norecurse nounwind optnone ssp uwtable(sync) "frame-pointer"="non-leaf" "no-trapping-math"="true" "probe-stack"="__chkstk_darwin" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+altnzcv,+bti,+ccdp,+ccidx,+complxnum,+crc,+dit,+dotprod,+flagm,+fp-armv8,+fp16fml,+fptoint,+fullfp16,+jsconv,+lse,+neon,+pauth,+perfmon,+predres,+ras,+rcpc,+rdm,+sb,+sha2,+sha3,+specrestrict,+ssbs,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 2, !"SDK Version", [2 x i32] [i32 15, i32 5]}
+!1 = !{i32 1, !"wchar_size", i32 4}
+!2 = !{i32 8, !"PIC Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 1}
+!4 = !{i32 7, !"frame-pointer", i32 1}
+!5 = !{!"Apple clang version 17.0.0 (clang-1700.0.13.5)"}


### PR DESCRIPTION
This PR introduces a new Clang-based tool: FunctionScopeIdentifier.

The tool identifies C/C++ functions that span specific line ranges in a source file. It extends Clang’s tooling interface by supporting a custom command-line option:
-identify-scope-range=<comma-separated line ranges>

Example usage:
./bin/FunctionScopeIdentifier -identify-scope-range=5-10,12-15 test.cpp -- -std=c++17
The tool reports all functions that overlap with the specified line ranges, including the function name and its start/end lines. This can assist with code analysis, refactoring, and tooling automation.

Key Features
Accepts multiple line ranges via -identify-scope-range (e.g. 5-10,12-18)

Uses Clang AST matchers to identify function declarations with bodies

Outputs function names and their source line spans that intersect the given ranges

Supports standard Clang compilation arguments (e.g. -I, -D)
Files Added
clang/tools/FunctionScopeIdentifier/FunctionScopeIdentifier.cpp

clang/tools/FunctionScopeIdentifier/CMakeLists.txt

test-files/test.cpp

test-files/test1.cpp

test-files/test.ll (IR generated for validation)